### PR TITLE
fix: add localectl to doas.conf and remove setup-result.json on reconfigure

### DIFF
--- a/kickstart/xiboplayer-kiosk.ks
+++ b/kickstart/xiboplayer-kiosk.ks
@@ -212,6 +212,7 @@ cat > /etc/doas.conf << 'EOF'
 permit nopass xibo cmd reboot
 permit nopass xibo cmd shutdown
 permit nopass xibo cmd alternatives
+permit nopass xibo cmd localectl
 EOF
 chmod 600 /etc/doas.conf
 %end

--- a/kiosk/xibo-show-cms.sh
+++ b/kiosk/xibo-show-cms.sh
@@ -14,6 +14,7 @@ if zenity --question --title="Xibo" \
         systemctl --user stop "$svc" 2>/dev/null || true
     done
     rm -f "${XIBO_DATA_DIR}/cms.json"
+    rm -f "${XIBO_DATA_DIR}/setup-result.json"
     rm -f "${XIBO_DATA_DIR}/env"
     pkill -u "$(whoami)" -f gnome-kiosk-script 2>/dev/null || true
     exec "${XIBO_KIOSK_DIR}/gnome-kiosk-script.xibo-init.sh"

--- a/mkosi-extra/etc/doas.conf
+++ b/mkosi-extra/etc/doas.conf
@@ -1,3 +1,4 @@
 permit nopass xibo cmd reboot
 permit nopass xibo cmd shutdown
 permit nopass xibo cmd alternatives
+permit nopass xibo cmd localectl


### PR DESCRIPTION
## Summary
1. **doas.conf**: Add `permit nopass xibo cmd localectl` — language selection in the setup wizard was silently failing
2. **xibo-show-cms.sh**: Remove `setup-result.json` during Ctrl+R reconfigure — prevents wizard being skipped after reboot

## Test plan
- [ ] First boot: select non-English language → system locale changes
- [ ] Ctrl+R reconfigure → reboot mid-wizard → wizard appears again (not skipped)
- [ ] Kickstart install: verify doas.conf has localectl line

Closes #32, closes #33