### PR TITLE
ci: add concurrency groups, timeouts, remove stale pip install

### DIFF
--- a/.github/workflows/atomic.yml
+++ b/.github/workflows/atomic.yml
@@ -18,10 +18,15 @@ env:
   IMAGE_NAME: xibo-players/xiboplayer-kiosk
   FEDORA_VERSION: '43'
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: false
+
 jobs:
   build-oci-x86_64:
     name: Build OCI Image (x86_64)
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v6
@@ -43,6 +48,7 @@ jobs:
   build-oci-aarch64:
     name: Build OCI Image (aarch64)
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v6
@@ -65,6 +71,7 @@ jobs:
     name: Push multi-arch manifest
     needs: [build-oci-x86_64, build-oci-aarch64]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Log in to GitHub Container Registry
@@ -91,6 +98,7 @@ jobs:
     name: Build ISO (x86_64)
     needs: build-oci-x86_64
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v6
@@ -141,6 +149,7 @@ jobs:
     name: Build ISO (aarch64)
     needs: build-oci-aarch64
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v6
@@ -192,6 +201,7 @@ jobs:
     needs: [build-iso-x86_64, build-iso-aarch64, push-manifest]
     if: always() && (needs.build-iso-x86_64.result == 'success' || needs.build-iso-aarch64.result == 'success')
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v6
@@ -224,7 +234,7 @@ jobs:
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
           TAG: ${{ steps.version.outputs.tag }}
         run: |
-          pip install awscli 2>/dev/null || true
+          # awscli installed via rpm in the runner image
           BUCKET="${R2_BUCKET}"
           DEST="$BUCKET/xiboplayer-kiosk-atomic/${TAG}"
 

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -6,6 +6,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: false
+
 jobs:
   deb:
     uses: xibo-players/.github/.github/workflows/build-deb.yml@main

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: false
+
 jobs:
   build:
     uses: xibo-players/.github/.github/workflows/build-iso.yml@main

--- a/.github/workflows/ipxe.yml
+++ b/.github/workflows/ipxe.yml
@@ -9,10 +9,15 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   build-ipxe:
     name: Build iPXE image
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     container:
       image: ubuntu:24.04
 

--- a/.github/workflows/qcow2-bootc.yml
+++ b/.github/workflows/qcow2-bootc.yml
@@ -7,10 +7,15 @@ permissions:
   contents: write
   packages: read
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   build:
     name: QCOW2 from bootc
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/qcow2.yml
+++ b/.github/workflows/qcow2.yml
@@ -6,6 +6,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   build:
     uses: xibo-players/.github/.github/workflows/build-iso.yml@main

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -6,6 +6,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: false
+
 jobs:
   rpm:
     uses: xibo-players/.github/.github/workflows/build-rpm.yml@main


### PR DESCRIPTION
## Summary
- Concurrency groups on all 7 workflows (cancel-in-progress: false for release workflows)
- timeout-minutes: 60 for image builds, 30 for lightweight
- Remove stale `pip install awscli` (installed via rpm)

Closes #26, closes #27, closes #28