### PR TITLE
fix: increase setup wizard window sizes

### DIFF
--- a/kiosk/gnome-kiosk-script.xibo-init.sh
+++ b/kiosk/gnome-kiosk-script.xibo-init.sh
@@ -51,7 +51,7 @@ if [ ! -f "${XIBO_DATA_DIR}/setup-result.json" ]; then
             "xiboplayer-electron" "Electron (recommended)" \
             "xiboplayer-chromium" "Chromium (lightweight)" \
             "arexibo" "arexibo (native Rust)" \
-            --width=400 --height=300 2>&1)
+            --width=500 --height=400 2>&1)
 
         [ -z "$PLAYER" ] && PLAYER="xiboplayer-electron"
 

--- a/kiosk/xiboplayer-setup.py
+++ b/kiosk/xiboplayer-setup.py
@@ -330,8 +330,8 @@ class SetupWindow(Adw.ApplicationWindow):
     def __init__(self, app):
         super().__init__(
             application=app,
-            default_width=600,
-            default_height=500,
+            default_width=700,
+            default_height=550,
         )
 
         toolbar = Adw.ToolbarView()


### PR DESCRIPTION
Closes #9. Reported in S6#91, #170.