### PR TITLE
fix: add arm64 to kiosk DEB build matrix

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -17,6 +17,7 @@ jobs:
       package-name: xiboplayer-kiosk
       deb-script: 'deb/build-deb.sh'
       distro-matrix: '["ubuntu:24.04", "debian:trixie"]'
+      arch-matrix: '["amd64", "arm64"]'
       default-version: '0.4.15'
       gpg-sign: true
       publish-to-repo: true


### PR DESCRIPTION
Refs #25. DEB now builds amd64 + arm64. RPM is noarch. ISO already has both.