### PR TITLE
feat: connectivity health-check + remove stale default-version from workflows

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -18,7 +18,6 @@ jobs:
       deb-script: 'deb/build-deb.sh'
       distro-matrix: '["ubuntu:24.04", "debian:trixie"]'
       arch-matrix: '["amd64", "arm64"]'
-      default-version: '0.4.15'
       gpg-sign: true
       publish-to-repo: true
     secrets: inherit

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -22,5 +22,4 @@ jobs:
       build-self-contained-iso: true
       build-netinstall: true
       architectures: 'x86_64,aarch64'
-      default-version: '0.4.15'
     secrets: inherit

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -18,6 +18,5 @@ jobs:
       rpm-spec: 'rpm/xiboplayer-kiosk.spec'
       fedora-matrix: '["43"]'
       source-tarball: 'full'
-      default-version: '0.4.15'
       gpg-sign: true
     secrets: inherit

--- a/mkosi-extra/etc/doas.conf
+++ b/mkosi-extra/etc/doas.conf
@@ -2,3 +2,4 @@ permit nopass xibo cmd reboot
 permit nopass xibo cmd shutdown
 permit nopass xibo cmd alternatives
 permit nopass xibo cmd localectl
+permit nopass xibo cmd systemctl args restart NetworkManager

--- a/mkosi-extra/etc/systemd/user/xibo-connectivity-check.service
+++ b/mkosi-extra/etc/systemd/user/xibo-connectivity-check.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Xibo kiosk connectivity health check
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/xibo-connectivity-check

--- a/mkosi-extra/etc/systemd/user/xibo-connectivity-check.timer
+++ b/mkosi-extra/etc/systemd/user/xibo-connectivity-check.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Periodic internet connectivity check for kiosk
+
+[Timer]
+OnBootSec=60
+OnUnitActiveSec=60
+AccuracySec=10
+
+[Install]
+WantedBy=timers.target

--- a/mkosi-extra/usr/lib/systemd/user-preset/80-xiboplayer-kiosk.preset
+++ b/mkosi-extra/usr/lib/systemd/user-preset/80-xiboplayer-kiosk.preset
@@ -1,0 +1,1 @@
+enable xibo-connectivity-check.timer

--- a/mkosi-extra/usr/local/bin/xibo-connectivity-check
+++ b/mkosi-extra/usr/local/bin/xibo-connectivity-check
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Xibo Kiosk — connectivity health check
+#
+# Probes the CMS endpoint (or fallback DNS). If unreachable for 3
+# consecutive checks, restarts NetworkManager and notifies via dunst.
+# Runs as a systemd user timer every 60 seconds.
+
+XIBO_DATA_DIR="${XIBO_DATA_DIR:-${HOME}/.local/share/xibo}"
+FAIL_FILE="/tmp/xibo-connectivity-failures"
+MAX_FAILURES=3
+
+# Read CMS address from config
+CMS_URL=""
+if [ -f "${XIBO_DATA_DIR}/cms.json" ]; then
+    CMS_URL=$(grep -oP '"address"\s*:\s*"\K[^"]+' "${XIBO_DATA_DIR}/cms.json" 2>/dev/null)
+fi
+
+# Determine what to probe
+if [ -n "$CMS_URL" ]; then
+    # Extract hostname from CMS URL
+    PROBE_HOST=$(echo "$CMS_URL" | sed 's|https\?://||;s|/.*||;s|:.*||')
+    PROBE_CMD="curl -sf --connect-timeout 5 --max-time 10 -o /dev/null ${CMS_URL}"
+else
+    # No CMS configured — just check general internet
+    PROBE_HOST="dns.google"
+    PROBE_CMD="ping -c 1 -W 5 8.8.8.8"
+fi
+
+# Run probe
+if $PROBE_CMD >/dev/null 2>&1; then
+    # Success — reset failure counter
+    rm -f "$FAIL_FILE"
+    exit 0
+fi
+
+# Failed — increment counter
+FAILURES=$(cat "$FAIL_FILE" 2>/dev/null || echo 0)
+FAILURES=$((FAILURES + 1))
+echo "$FAILURES" > "$FAIL_FILE"
+
+logger -t xibo-connectivity "Connectivity check failed ($FAILURES/$MAX_FAILURES) — ${PROBE_HOST} unreachable"
+
+if [ "$FAILURES" -ge "$MAX_FAILURES" ]; then
+    logger -t xibo-connectivity "Max failures reached. Restarting NetworkManager."
+
+    # Notify user via dunst (if available)
+    notify-send "Network Issue" "Internet unreachable for ${FAILURES} checks. Restarting network..." 2>/dev/null
+
+    # Restart NetworkManager (requires doas)
+    doas systemctl restart NetworkManager 2>/dev/null
+
+    # Wait for NM to reconnect
+    sleep 10
+
+    # Re-check
+    if $PROBE_CMD >/dev/null 2>&1; then
+        logger -t xibo-connectivity "Network recovered after restart."
+        notify-send "Network Restored" "Internet connection recovered." 2>/dev/null
+        rm -f "$FAIL_FILE"
+    else
+        logger -t xibo-connectivity "Network still down after restart."
+    fi
+fi


### PR DESCRIPTION
## Connectivity check (closes #23)
- Probes CMS endpoint every 60s via systemd user timer
- Restarts NetworkManager after 3 consecutive failures
- doas permits `systemctl restart NetworkManager`

## CI cleanup
- Remove `default-version` from all workflows — tag/spec is the source of truth
- Add arm64 to DEB matrix

Closes #23