### PR TITLE
fix: add mirrorlist URL to kickstart for netinstall

### DIFF
--- a/kickstart/xiboplayer-kiosk.ks
+++ b/kickstart/xiboplayer-kiosk.ks
@@ -9,6 +9,11 @@
 #
 # Or create a custom ISO with this kickstart embedded.
 
+# Installation source — Fedora mirror for netinstall, cdrom for Everything ISO
+# Anaconda auto-detects cdrom when booting from Everything ISO and ignores url.
+# For netinstall, the mirrorlist provides automatic mirror selection.
+url --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-43&arch=$basearch
+
 # Installation settings
 text
 skipx


### PR DESCRIPTION
## Problem
Kickstart had no installation source — Anaconda fell back to interactive mirror selection which fails in VMs and behind firewalls.

## Fix
Add `url --mirrorlist=...` for Fedora 43. Anaconda auto-detects cdrom for Everything ISO and ignores the URL.

Closes #24