### PR TITLE
fix: arch-specific shim for aarch64 mkosi builds

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -18,7 +18,6 @@ Packages=
     kernel-core
     efibootmgr
     systemd-boot-unsigned
-    shim-x64
     gdm
     gnome-kiosk
     gnome-kiosk-script-session

--- a/mkosi.conf.d/10-shim-aarch64.conf
+++ b/mkosi.conf.d/10-shim-aarch64.conf
@@ -1,0 +1,6 @@
+[Match]
+Architecture=arm64
+
+[Content]
+Packages=
+    shim-aa64

--- a/mkosi.conf.d/10-shim-x86_64.conf
+++ b/mkosi.conf.d/10-shim-x86_64.conf
@@ -1,0 +1,6 @@
+[Match]
+Architecture=x86-64
+
+[Content]
+Packages=
+    shim-x64


### PR DESCRIPTION
aarch64 disk images failed because shim-x64 doesn't exist on ARM. Split into mkosi.conf.d/ per-arch overrides.