### PR TITLE
feat: upload Atomic ISOs to GitHub Releases

### DIFF
--- a/.github/workflows/atomic.yml
+++ b/.github/workflows/atomic.yml
@@ -315,3 +315,10 @@ jobs:
           gh release view "$TAG" --json tagName >/dev/null 2>&1 || \
             gh release create "$TAG" --title "Kiosk Atomic $TAG" --notes ""
           gh release edit "$TAG" --notes "$NOTES"
+
+          # Upload ISOs + checksums to GitHub Release (< 2GB each, fits GH limits)
+          for f in release/*.iso release/SHA256SUMS; do
+            [ -f "$f" ] || continue
+            echo "Uploading $(basename $f) to GH Release..."
+            gh release upload "$TAG" "$f" --clobber || true
+          done


### PR DESCRIPTION
Atomic ISOs are <2GB, fit GH limits. Users get all images in one place.