### PR TITLE
fix: QCOW2 images fail to boot — missing kernel command line

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -11,6 +11,7 @@ OutputDirectory=output
 Bootable=yes
 Bootloader=systemd-boot
 UnifiedKernelImages=no
+KernelCommandLine=root=gpt-auto quiet rhgb
 RootPassword=root
 ExtraTrees=mkosi-extra
 Packages=


### PR DESCRIPTION
Boot entry had empty `options` line — no root= parameter. Kernel couldn't find root.

Fix: `KernelCommandLine=root=gpt-auto quiet rhgb` — uses systemd GPT auto-discovery.

Reported by 0x0 in S6#235.