### PR TITLE
feat: redesign first-boot flow — GNOME setup then kiosk lockdown

### DIFF
--- a/deb/build-deb.sh
+++ b/deb/build-deb.sh
@@ -27,6 +27,9 @@ install -m755 kiosk/xibo-keyd-run.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 install -m755 kiosk/xibo-show-ip.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 install -m755 kiosk/xibo-show-cms.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 install -m755 kiosk/xiboplayer-setup.py "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
+install -m644 kiosk/xiboplayer-setup.desktop "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
+install -m755 kiosk/xibo-activate-kiosk.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
+install -m755 kiosk/xibo-deactivate-kiosk.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 
 # Install dispatcher to skel (copied to new users' ~/.local/bin/)
 install -m755 kiosk/gnome-kiosk-script.sh "${DEB_DIR}/etc/skel/.local/bin/gnome-kiosk-script"

--- a/kickstart/grub.cfg
+++ b/kickstart/grub.cfg
@@ -1,0 +1,30 @@
+# xiboplayer kiosk — UEFI boot menu
+# All three players are installed. The selected entry sets the default.
+# Press Ctrl+R after boot to switch player at any time.
+
+set default=0
+set timeout=10
+
+insmod gfxterm
+set gfxmode=auto
+terminal_output gfxterm
+
+set menu_color_normal=white/black
+set menu_color_highlight=white/blue
+
+menuentry '── xiboplayer kiosk ── all players installed, use Ctrl+R to switch anytime ──' --unrestricted { true ; }
+
+menuentry 'Chromium player (recommended)' --class fedora --class os {
+    linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-S-dvd-x86_64-43 inst.ks=https://raw.githubusercontent.com/xibo-players/xiboplayer-kiosk/main/kickstart/xiboplayer-kiosk.ks xibo.profile=chromium quiet
+    initrdefi /images/pxeboot/initrd.img
+}
+
+menuentry 'Electron player' --class fedora --class os {
+    linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-S-dvd-x86_64-43 inst.ks=https://raw.githubusercontent.com/xibo-players/xiboplayer-kiosk/main/kickstart/xiboplayer-kiosk.ks xibo.profile=electron quiet
+    initrdefi /images/pxeboot/initrd.img
+}
+
+menuentry 'Arexibo player' --class fedora --class os {
+    linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=Fedora-S-dvd-x86_64-43 inst.ks=https://raw.githubusercontent.com/xibo-players/xiboplayer-kiosk/main/kickstart/xiboplayer-kiosk.ks xibo.profile=arexibo quiet
+    initrdefi /images/pxeboot/initrd.img
+}

--- a/kickstart/isolinux.cfg
+++ b/kickstart/isolinux.cfg
@@ -1,0 +1,25 @@
+# xiboplayer kiosk — BIOS boot menu
+# All three players are installed. The selected entry sets the default.
+# Press Ctrl+R after boot to switch player at any time.
+
+default vesamenu.c32
+timeout 100
+totaltimeout 6000
+
+menu title xiboplayer kiosk — all players installed, use Ctrl+R to switch anytime
+
+label chromium
+  menu label Chromium player (recommended)
+  menu default
+  kernel vmlinuz
+  append initrd=initrd.img inst.stage2=hd:LABEL=Fedora-S-dvd-x86_64-43 inst.ks=https://raw.githubusercontent.com/xibo-players/xiboplayer-kiosk/main/kickstart/xiboplayer-kiosk.ks xibo.profile=chromium quiet
+
+label electron
+  menu label Electron player
+  kernel vmlinuz
+  append initrd=initrd.img inst.stage2=hd:LABEL=Fedora-S-dvd-x86_64-43 inst.ks=https://raw.githubusercontent.com/xibo-players/xiboplayer-kiosk/main/kickstart/xiboplayer-kiosk.ks xibo.profile=electron quiet
+
+label arexibo
+  menu label Arexibo player
+  kernel vmlinuz
+  append initrd=initrd.img inst.stage2=hd:LABEL=Fedora-S-dvd-x86_64-43 inst.ks=https://raw.githubusercontent.com/xibo-players/xiboplayer-kiosk/main/kickstart/xiboplayer-kiosk.ks xibo.profile=arexibo quiet

--- a/kickstart/xiboplayer-kiosk.ks
+++ b/kickstart/xiboplayer-kiosk.ks
@@ -17,7 +17,7 @@ url --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-43&arc
 # Installation settings
 text
 skipx
-firstboot --enable
+firstboot --disable
 reboot --eject
 
 # Localization
@@ -150,29 +150,38 @@ dnf install -y --nogpgcheck xiboplayer-release || \
   dnf install -y --nogpgcheck \
   https://dl.xiboplayer.org/rpm/fedora/43/noarch/xiboplayer-release-43-7.fc43.noarch.rpm
 
-# Install players based on xibo.profile kernel parameter
-# Profiles: full (default), electron, chromium
-# Set via iPXE: kernel vmlinuz inst.ks=... xibo.profile=electron
+# Install ALL players — the boot menu selects the default via xibo.profile=
+# Profiles: chromium (default), electron, arexibo
+# Set via ISO boot menu or iPXE: kernel vmlinuz inst.ks=... xibo.profile=electron
+dnf install -y xiboplayer-kiosk xiboplayer-chromium xiboplayer-electron arexibo
+
+# Register all players with alternatives
+alternatives --install /usr/bin/xiboplayer xiboplayer /usr/bin/xiboplayer-chromium 30
+alternatives --install /usr/bin/xiboplayer xiboplayer /usr/bin/xiboplayer-electron 20
+alternatives --install /usr/bin/xiboplayer xiboplayer /usr/bin/arexibo 10
+
+# Set default player from xibo.profile kernel parameter
 PROFILE=$(sed -n 's/.*xibo\.profile=\([^ ]*\).*/\1/p' /proc/cmdline)
-PROFILE="${PROFILE:-full}"
+PROFILE="${PROFILE:-chromium}"
 
 case "$PROFILE" in
   electron)
-    dnf install -y xiboplayer-kiosk xiboplayer-electron
-    alternatives --install /usr/bin/xiboplayer xiboplayer /usr/bin/xiboplayer-electron 20
-    ;;
-  chromium)
-    dnf install -y xiboplayer-kiosk xiboplayer-chromium
-    alternatives --install /usr/bin/xiboplayer xiboplayer /usr/bin/xiboplayer-chromium 30
-    ;;
+    alternatives --set xiboplayer /usr/bin/xiboplayer-electron
+    PLAYER="Electron"; SERVICE="xiboplayer-electron.service" ;;
+  arexibo)
+    alternatives --set xiboplayer /usr/bin/arexibo
+    PLAYER="Arexibo"; SERVICE="arexibo.service" ;;
   *)
-    dnf install -y xiboplayer-kiosk xiboplayer-electron xiboplayer-chromium arexibo
-    alternatives --install /usr/bin/xiboplayer xiboplayer /usr/bin/xiboplayer-electron 20
-    alternatives --install /usr/bin/xiboplayer xiboplayer /usr/bin/xiboplayer-chromium 30
-    alternatives --install /usr/bin/xiboplayer xiboplayer /usr/bin/arexibo 10
-    ;;
+    alternatives --set xiboplayer /usr/bin/xiboplayer-chromium
+    PLAYER="Chromium"; SERVICE="xiboplayer-chromium.service" ;;
 esac
-echo "Installed profile: $PROFILE"
+
+# Write setup-result.json so the kiosk knows which player to start
+cat > /home/xibo/.local/share/xibo/setup-result.json << SETUPEOF
+{"player": "$PLAYER", "service": "$SERVICE"}
+SETUPEOF
+chown xibo:xibo /home/xibo/.local/share/xibo/setup-result.json
+echo "Default player: $PLAYER ($SERVICE)"
 %end
 
 # Configure xibo user and directories
@@ -205,12 +214,13 @@ AutomaticLogin=xibo
 EOF
 %end
 
-# Configure AccountsService
+# Configure AccountsService — default GNOME session for first boot
+# The setup wizard will switch to gnome-kiosk-script-wayland after configuration
 %post --erroronfail
 mkdir -p /var/lib/AccountsService/users
 cat > /var/lib/AccountsService/users/xibo << 'EOF'
 [User]
-Session=gnome-kiosk-script-wayland
+Session=gnome
 SystemAccount=false
 EOF
 %end
@@ -222,6 +232,9 @@ permit nopass xibo cmd reboot
 permit nopass xibo cmd shutdown
 permit nopass xibo cmd alternatives
 permit nopass xibo cmd localectl
+permit nopass xibo cmd timedatectl
+permit nopass xibo cmd /usr/share/xiboplayer-kiosk/xibo-activate-kiosk.sh
+permit nopass xibo cmd /usr/share/xiboplayer-kiosk/xibo-deactivate-kiosk.sh
 EOF
 chmod 600 /etc/doas.conf
 %end
@@ -254,13 +267,21 @@ chmod 755 /home/xibo/.local/bin/shutdown
 chown xibo:xibo /home/xibo/.local/bin/reboot /home/xibo/.local/bin/shutdown
 %end
 
-# gnome-initial-setup: only show locale/keyboard/network/timezone
+# Skip gnome-initial-setup completely — our wizard handles system config
 %post --erroronfail
 mkdir -p /usr/share/gnome-initial-setup
 cat > /usr/share/gnome-initial-setup/vendor.conf << 'EOF'
 [pages]
-skip=privacy;software;account;summary;welcome
+skip=language;keyboard;network;timezone;privacy;software;account;summary;welcome;password
 EOF
+systemctl mask gnome-initial-setup.service gnome-initial-setup-first-login.service
+%end
+
+# Install setup wizard autostart for first boot (normal GNOME session)
+%post --erroronfail
+mkdir -p /home/xibo/.config/autostart
+cp /usr/share/xiboplayer-kiosk/xiboplayer-setup.desktop /home/xibo/.config/autostart/
+chown -R xibo:xibo /home/xibo/.config/autostart
 %end
 
 # Disable GNOME donation popup

--- a/kiosk/gnome-kiosk-script.sh
+++ b/kiosk/gnome-kiosk-script.sh
@@ -1,15 +1,10 @@
 #!/bin/bash
 # Xibo Kiosk Dispatcher
 # =====================
-# Dispatches to the registration wizard or session holder based on
-# whether cms.json exists. This script is installed as the GNOME Kiosk
-# session script (gnome-kiosk-script in $PATH).
+# Runs inside gnome-kiosk-script-wayland session (after first-boot wizard
+# has already completed in the normal GNOME session).
+# Always starts the session holder which manages the selected player.
 
 XIBO_KIOSK_DIR="${XIBO_KIOSK_DIR:-/usr/share/xiboplayer-kiosk}"
-XIBO_DATA_DIR="${XIBO_DATA_DIR:-${HOME}/.local/share/xibo}"
 
-if [ -f "${XIBO_DATA_DIR}/setup-result.json" ]; then
-    exec "${XIBO_KIOSK_DIR}/gnome-kiosk-script.xibo.sh"
-else
-    exec "${XIBO_KIOSK_DIR}/gnome-kiosk-script.xibo-init.sh"
-fi
+exec "${XIBO_KIOSK_DIR}/gnome-kiosk-script.xibo.sh"

--- a/kiosk/gnome-kiosk-script.xibo-init.sh
+++ b/kiosk/gnome-kiosk-script.xibo-init.sh
@@ -1,77 +1,40 @@
 #!/bin/bash
-# Xibo First-Boot Setup
-# ======================
-# Runs xiboplayer-setup (player selection).
-# Then hands off to the session holder.
-#
-# gnome-initial-setup is skipped — locale/timezone/keyboard are set
-# by the image defaults or by Ansible provisioning.
+# Xibo Kiosk Init (legacy fallback)
+# ==================================
+# This script is kept for backward compatibility and edge cases where
+# the first-boot wizard (xiboplayer-setup.py) did not run in GNOME.
+# The normal flow is: GNOME session → wizard autostart → kiosk forever.
+# This only runs if the dispatcher is somehow reached without setup.
 
 XIBO_KIOSK_DIR="${XIBO_KIOSK_DIR:-/usr/share/xiboplayer-kiosk}"
 XIBO_DATA_DIR="${XIBO_DATA_DIR:-${HOME}/.local/share/xibo}"
 LOGFILE="/tmp/xibo-init.log"
-NOTIFY_ID=1
 
-# Log everything
 exec > >(tee -a "$LOGFILE") 2>&1
-echo "=== xibo-init started at $(date -Iseconds) ==="
+echo "=== xibo-init fallback started at $(date -Iseconds) ==="
 
 # Start dunst for notifications
 dunst -conf "${XIBO_KIOSK_DIR}/dunstrc" &
-
-# Wait for Wayland compositor
 sleep 2
 
 # Import display environment into systemd user manager
 systemctl --user import-environment WAYLAND_DISPLAY DISPLAY XDG_RUNTIME_DIR
 
-# Disable donation popup
-gsettings set org.gnome.desktop.interface show-donation-popup false 2>/dev/null || true
-
-# Skip gnome-initial-setup — mark as done so it never runs
+# Mark gnome-initial-setup as done
 mkdir -p "${HOME}/.config"
 touch "${HOME}/.config/gnome-initial-setup-done"
 
-# ── Player setup ─────────────────────────────────────────────────────────────
-echo "[Setup] Checking setup-result.json..."
+# If no setup-result.json, create one with Chromium default
 if [ ! -f "${XIBO_DATA_DIR}/setup-result.json" ]; then
     mkdir -p "${XIBO_DATA_DIR}"
-    echo "[Setup] Launching player setup wizard..."
-
-    # Try libadwaita wizard
-    if [ -f "${XIBO_KIOSK_DIR}/xiboplayer-setup.py" ] && \
-       python3 "${XIBO_KIOSK_DIR}/xiboplayer-setup.py" 2>&1; then
-        echo "[Setup] Wizard completed."
-    else
-        echo "[Setup] Wizard failed (exit $?). Using zenity fallback..."
-
-        PLAYER=$(zenity --list --title="Xibo Player Setup" \
-            --text="Select a player:" \
-            --column="Player" --column="Description" \
-            "xiboplayer-chromium" "Chromium (recommended)" \
-            "xiboplayer-electron" "Electron" \
-            "arexibo" "arexibo (native Rust)" \
-            --width=500 --height=400 2>&1)
-
-        [ -z "$PLAYER" ] && PLAYER="xiboplayer-chromium"
-
-        case "$PLAYER" in
-            xiboplayer-chromium) SERVICE="xiboplayer-chromium.service" ;;
-            arexibo) SERVICE="arexibo.service" ;;
-            *) PLAYER="xiboplayer-chromium"; SERVICE="xiboplayer-chromium.service" ;;
-        esac
-
-        doas alternatives --set xiboplayer "/usr/bin/${PLAYER}" 2>/dev/null || true
-
-        cat > "${XIBO_DATA_DIR}/setup-result.json" << EOF
-{"player": "${PLAYER}", "service": "${SERVICE}"}
+    cat > "${XIBO_DATA_DIR}/setup-result.json" << 'EOF'
+{"player": "Chromium", "service": "xiboplayer-chromium.service"}
 EOF
-        echo "[Setup] Selected: $PLAYER ($SERVICE)"
-    fi
+    echo "[Init] Created default setup-result.json (Chromium)"
 fi
 
-# ── Hand off to session holder ───────────────────────────────────────────────
-echo "[Setup] Starting session holder..."
+# Hand off to session holder
+echo "[Init] Starting session holder..."
 sleep 2
 pkill -u "$(whoami)" dunst 2>/dev/null || true
 exec "${XIBO_KIOSK_DIR}/gnome-kiosk-script.xibo.sh"

--- a/kiosk/xibo-activate-kiosk.sh
+++ b/kiosk/xibo-activate-kiosk.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Switch AccountsService session to kiosk mode.
+# Called via doas by xiboplayer-setup.py after first-boot configuration.
+# After this, GDM will launch gnome-kiosk-script-wayland on next login.
+
+cat > /var/lib/AccountsService/users/xibo << 'EOF'
+[User]
+Session=gnome-kiosk-script-wayland
+SystemAccount=false
+EOF

--- a/kiosk/xibo-deactivate-kiosk.sh
+++ b/kiosk/xibo-deactivate-kiosk.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Revert AccountsService to normal GNOME session.
+# Called via doas by xibo-show-cms.sh for full reconfiguration.
+
+cat > /var/lib/AccountsService/users/xibo << 'EOF'
+[User]
+Session=gnome
+SystemAccount=false
+EOF

--- a/kiosk/xibo-show-cms.sh
+++ b/kiosk/xibo-show-cms.sh
@@ -1,21 +1,73 @@
 #!/bin/bash
-# Show CMS server and display name, offer reconfiguration.
+# Show CMS/player status, offer reconfiguration.
 # Triggered by Ctrl+R (via keyd).
 XIBO_KIOSK_DIR="${XIBO_KIOSK_DIR:-/usr/share/xiboplayer-kiosk}"
 XIBO_DATA_DIR="${XIBO_DATA_DIR:-${HOME}/.local/share/xibo}"
-CMS=$(grep -oP '"address"\s*:\s*"\K[^"]+' "${XIBO_DATA_DIR}/cms.json" 2>/dev/null || echo "not configured")
-DISPLAY_NAME=$(grep -oP '"display_name"\s*:\s*"\K[^"]+' "${XIBO_DATA_DIR}/cms.json" 2>/dev/null || echo "unknown")
-PLAYER=$(basename "$(readlink /etc/alternatives/xiboplayer 2>/dev/null)" 2>/dev/null || echo "unknown")
-if zenity --question --title="Xibo" \
-    --text="CMS Server: $CMS\nDisplay: $DISPLAY_NAME\nPlayer: $PLAYER\n\nReconfigure CMS connection?\n\nThis will stop the player and start the setup wizard." \
-    --width=300 2>/dev/null; then
-    # Stop whichever player service is running
-    for svc in arexibo.service xiboplayer-electron.service xiboplayer-chromium.service; do
-        systemctl --user stop "$svc" 2>/dev/null || true
-    done
-    rm -f "${XIBO_DATA_DIR}/cms.json"
-    rm -f "${XIBO_DATA_DIR}/setup-result.json"
-    rm -f "${XIBO_DATA_DIR}/env"
-    pkill -u "$(whoami)" -f gnome-kiosk-script 2>/dev/null || true
-    exec "${XIBO_KIOSK_DIR}/gnome-kiosk-script.xibo-init.sh"
-fi
+
+# Read current player
+PLAYER=$(python3 -c "import json; print(json.load(open('${XIBO_DATA_DIR}/setup-result.json'))['player'])" 2>/dev/null || echo "unknown")
+SERVICE=$(python3 -c "import json; print(json.load(open('${XIBO_DATA_DIR}/setup-result.json'))['service'])" 2>/dev/null || echo "unknown")
+
+# Get CMS info based on player type
+case "$PLAYER" in
+    Arexibo)
+        CMS=$(grep -oP '"address"\s*:\s*"\K[^"]+' "${XIBO_DATA_DIR}/cms.json" 2>/dev/null || echo "not configured")
+        DISPLAY_NAME=$(grep -oP '"display_name"\s*:\s*"\K[^"]+' "${XIBO_DATA_DIR}/cms.json" 2>/dev/null || echo "unknown")
+        ;;
+    Chromium|Electron)
+        SUBDIR=$(echo "$PLAYER" | tr '[:upper:]' '[:lower:]')
+        CONFIG="$HOME/.config/xiboplayer/${SUBDIR}/config.json"
+        CMS=$(python3 -c "import json; print(json.load(open('${CONFIG}')).get('cmsUrl','not configured'))" 2>/dev/null || echo "not configured")
+        DISPLAY_NAME=$(python3 -c "import json; print(json.load(open('${CONFIG}')).get('displayName','unknown'))" 2>/dev/null || echo "unknown")
+        ;;
+    *)
+        CMS="unknown"
+        DISPLAY_NAME="unknown"
+        ;;
+esac
+
+ACTION=$(zenity --list --title="xiboplayer" \
+    --text="Player: $PLAYER\nCMS: $CMS\nDisplay: $DISPLAY_NAME\n\nChoose an action:" \
+    --column="Action" --column="Description" \
+    "reconfigure" "Reset player config and restart" \
+    "full-setup" "Return to first-boot wizard (WiFi, timezone, etc.)" \
+    "cancel" "Do nothing" \
+    --width=450 --height=350 2>/dev/null)
+
+case "$ACTION" in
+    reconfigure)
+        # Stop player
+        systemctl --user stop "$SERVICE" 2>/dev/null || true
+
+        # Delete player config so it re-shows its setup UI on restart
+        case "$PLAYER" in
+            Arexibo)
+                rm -f "${XIBO_DATA_DIR}/cms.json"
+                ;;
+            Chromium|Electron)
+                SUBDIR=$(echo "$PLAYER" | tr '[:upper:]' '[:lower:]')
+                rm -f "$HOME/.config/xiboplayer/${SUBDIR}/config.json"
+                ;;
+        esac
+
+        # Restart player
+        systemctl --user restart "$SERVICE" 2>/dev/null || true
+        ;;
+
+    full-setup)
+        # Stop all player services
+        for svc in arexibo.service xiboplayer-electron.service xiboplayer-chromium.service; do
+            systemctl --user stop "$svc" 2>/dev/null || true
+        done
+
+        # Re-add wizard autostart
+        mkdir -p "$HOME/.config/autostart"
+        cp "${XIBO_KIOSK_DIR}/xiboplayer-setup.desktop" "$HOME/.config/autostart/"
+
+        # Switch back to GNOME session for full reconfiguration
+        doas "${XIBO_KIOSK_DIR}/xibo-deactivate-kiosk.sh"
+
+        # Kill kiosk session — GDM will re-login into GNOME with wizard
+        pkill -u "$(whoami)" -f gnome-kiosk-script 2>/dev/null || true
+        ;;
+esac

--- a/kiosk/xiboplayer-setup.desktop
+++ b/kiosk/xiboplayer-setup.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=xiboplayer setup
+Comment=First-boot system configuration for xiboplayer kiosk
+Exec=/usr/share/xiboplayer-kiosk/xiboplayer-setup.py
+Icon=preferences-system
+X-GNOME-Autostart-enabled=true
+OnlyShowIn=GNOME;

--- a/kiosk/xiboplayer-setup.py
+++ b/kiosk/xiboplayer-setup.py
@@ -2,18 +2,21 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (c) 2026 Pau Aliagas <linuxnow@gmail.com>
 """
-Xibo Player Setup — follows gnome-initial-setup style exactly.
+xiboplayer first-boot setup wizard.
 
-Uses AdwStatusPage + AdwPreferencesGroup — same widget pattern as
-gnome-initial-setup language/timezone/account pages.
+Runs as autostart in a normal GNOME session on first boot.
+Provides buttons to launch native GNOME settings panels (WiFi, Date/Time,
+Language) and CMS configuration fields for Arexibo.
+
+On finish, activates kiosk mode via AccountsService and logs out.
+Subsequent boots go directly to gnome-kiosk with the selected player.
 """
 
-import locale
-import subprocess
 import hashlib
 import json
 import os
 import socket
+import subprocess
 import time
 
 import gi
@@ -22,56 +25,54 @@ gi.require_version('Adw', '1')
 from gi.repository import Gtk, Adw, GLib
 
 XIBO_DATA_DIR = os.path.expanduser('~/.local/share/xibo')
-
-# Common locales shown at the top of the language list.
-# Full list is loaded from localectl and searchable.
-COMMON_LOCALES = [
-    ('English (US)', 'en_US.UTF-8'),
-    ('English (UK)', 'en_GB.UTF-8'),
-    ('Español (España)', 'es_ES.UTF-8'),
-    ('Català', 'ca_ES.UTF-8'),
-    ('Français', 'fr_FR.UTF-8'),
-    ('Deutsch', 'de_DE.UTF-8'),
-    ('Italiano', 'it_IT.UTF-8'),
-    ('Português (Brasil)', 'pt_BR.UTF-8'),
-    ('Português (Portugal)', 'pt_PT.UTF-8'),
-    ('Nederlands', 'nl_NL.UTF-8'),
-    ('Polski', 'pl_PL.UTF-8'),
-    ('日本語', 'ja_JP.UTF-8'),
-    ('中文 (简体)', 'zh_CN.UTF-8'),
-    ('中文 (繁體)', 'zh_TW.UTF-8'),
-    ('한국어', 'ko_KR.UTF-8'),
-    ('العربية', 'ar_SA.UTF-8'),
-    ('Türkçe', 'tr_TR.UTF-8'),
-    ('Русский', 'ru_RU.UTF-8'),
-]
-
-PLAYERS = [
-    ('Electron', '/usr/bin/xiboplayer-electron', 'xiboplayer-electron.service',
-     'Web-based player with built-in setup UI', False),
-    ('Chromium', '/usr/bin/xiboplayer-chromium', 'xiboplayer-chromium.service',
-     'Chromium kiosk player with built-in setup UI (recommended)', True),
-    ('Arexibo', '/usr/bin/arexibo', 'arexibo.service',
-     'Native Rust player — requires CMS credentials', False),
-]
+SETUP_RESULT = os.path.join(XIBO_DATA_DIR, 'setup-result.json')
+KIOSK_DIR = '/usr/share/xiboplayer-kiosk'
+AUTOSTART_FILE = os.path.expanduser('~/.config/autostart/xiboplayer-setup.desktop')
 
 
-# ── Pages ─────────────────────────────────────────────────────
+def read_setup_result():
+    """Read the player selection written by kickstart."""
+    try:
+        with open(SETUP_RESULT) as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {'player': 'Chromium', 'service': 'xiboplayer-chromium.service'}
 
-def get_available_locales():
-    """Get all available locales from localectl."""
+
+def get_wifi_status():
+    """Get current WiFi SSID or connection status."""
     try:
         result = subprocess.run(
-            ['localectl', 'list-locales'],
+            ['nmcli', '-t', '-f', 'NAME,TYPE', 'connection', 'show', '--active'],
             capture_output=True, text=True, timeout=5,
         )
-        return [l.strip() for l in result.stdout.splitlines() if l.strip()]
+        for line in result.stdout.splitlines():
+            parts = line.split(':')
+            if len(parts) >= 2 and 'wireless' in parts[-1]:
+                return parts[0]
+        for line in result.stdout.splitlines():
+            parts = line.split(':')
+            if len(parts) >= 2 and 'ethernet' in parts[-1]:
+                return f'{parts[0]} (wired)'
     except Exception:
-        return [loc for _, loc in COMMON_LOCALES]
+        pass
+    return 'Not connected'
 
 
-def get_current_locale():
-    """Get the current system locale."""
+def get_timezone():
+    """Get current system timezone."""
+    try:
+        result = subprocess.run(
+            ['timedatectl', 'show', '-p', 'Timezone', '--value'],
+            capture_output=True, text=True, timeout=5,
+        )
+        return result.stdout.strip()
+    except Exception:
+        return 'Unknown'
+
+
+def get_locale():
+    """Get current system locale."""
     try:
         result = subprocess.run(
             ['localectl', 'status'],
@@ -85,174 +86,108 @@ def get_current_locale():
     return os.environ.get('LANG', 'en_US.UTF-8')
 
 
-def make_language_page():
-    """Language selection — searchable list like gnome-initial-setup language page."""
+def generate_display_id(key):
+    """Generate a unique display ID from machine-id + timestamp + key."""
+    machine_id = ''
+    try:
+        with open('/etc/machine-id') as f:
+            machine_id = f.read().strip()
+    except OSError:
+        pass
+    raw = f'{machine_id}{int(time.time())}{key}'
+    return f'xibo-{hashlib.sha256(raw.encode()).hexdigest()[:12]}'
+
+
+def launch_settings_panel(panel):
+    """Open a GNOME Settings panel."""
+    try:
+        subprocess.Popen(
+            ['gnome-control-center', panel],
+            start_new_session=True,
+        )
+    except Exception:
+        pass
+
+
+# ── Pages ─────────────────────────────────────────────────────
+
+
+def make_system_page():
+    """System configuration — buttons to launch native GNOME panels."""
     page = Adw.StatusPage(
-        title='Language',
-        description='Select the language for this device.',
+        title='System Setup',
+        description='Configure network and system settings for this device.',
+        icon_name='preferences-system-symbolic',
     )
-    page.selected_locale = get_current_locale()
 
     box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
 
-    # Search entry
-    search = Gtk.SearchEntry(placeholder_text='Search languages…')
-    search.set_margin_start(24)
-    search.set_margin_end(24)
-    box.append(search)
+    # Network / WiFi
+    net_group = Adw.PreferencesGroup(title='Network')
 
-    # Scrollable list of locales
-    scrolled = Gtk.ScrolledWindow(
-        vexpand=True,
-        min_content_height=300,
-        margin_start=24,
-        margin_end=24,
+    page.wifi_row = Adw.ActionRow(
+        title='WiFi',
+        subtitle=get_wifi_status(),
     )
+    page.wifi_row.set_activatable(True)
+    page.wifi_row.add_suffix(Gtk.Image.new_from_icon_name('go-next-symbolic'))
+    page.wifi_row.connect('activated', lambda _: launch_settings_panel('wifi'))
+    net_group.add(page.wifi_row)
 
-    listbox = Gtk.ListBox(selection_mode=Gtk.SelectionMode.SINGLE)
-    listbox.add_css_class('boxed-list')
-    listbox.set_filter_func(lambda row: True)
+    box.append(net_group)
 
-    # Build locale → display name map from common locales
-    locale_names = {loc: name for name, loc in COMMON_LOCALES}
-    all_locales = get_available_locales()
+    # Date & Time
+    time_group = Adw.PreferencesGroup(title='Date & Time')
 
-    # Common locales first, then the rest
-    common_codes = {loc for _, loc in COMMON_LOCALES}
-    ordered = [loc for _, loc in COMMON_LOCALES if loc in all_locales]
-    ordered += sorted(loc for loc in all_locales if loc not in common_codes)
+    page.tz_row = Adw.ActionRow(
+        title='Timezone',
+        subtitle=get_timezone(),
+    )
+    page.tz_row.set_activatable(True)
+    page.tz_row.add_suffix(Gtk.Image.new_from_icon_name('go-next-symbolic'))
+    page.tz_row.connect('activated', lambda _: launch_settings_panel('datetime'))
+    time_group.add(page.tz_row)
 
-    rows = []
-    first_selected = None
-    for loc in ordered:
-        display = locale_names.get(loc, loc)
-        row = Adw.ActionRow(title=display, subtitle=loc)
-        row._locale = loc
-        row._search_text = f'{display} {loc}'.lower()
-        listbox.append(row)
-        rows.append(row)
+    box.append(time_group)
 
-        if loc == page.selected_locale and first_selected is None:
-            first_selected = row
+    # Language (optional)
+    lang_group = Adw.PreferencesGroup(title='Language')
 
-    if first_selected:
-        listbox.select_row(first_selected)
+    page.lang_row = Adw.ActionRow(
+        title='Language & Region',
+        subtitle=get_locale(),
+    )
+    page.lang_row.set_activatable(True)
+    page.lang_row.add_suffix(Gtk.Image.new_from_icon_name('go-next-symbolic'))
+    page.lang_row.connect('activated', lambda _: launch_settings_panel('region'))
+    lang_group.add(page.lang_row)
 
-    def on_row_selected(lb, row):
-        if row:
-            page.selected_locale = row._locale
+    box.append(lang_group)
 
-    listbox.connect('row-selected', on_row_selected)
+    # Display (optional)
+    display_group = Adw.PreferencesGroup(title='Display')
 
-    # Search filtering
-    def on_search_changed(entry):
-        text = entry.get_text().lower()
-        listbox.set_filter_func(
-            lambda row: not text or text in row._search_text
-        )
+    display_row = Adw.ActionRow(
+        title='Display Settings',
+        subtitle='Resolution, rotation and scaling',
+    )
+    display_row.set_activatable(True)
+    display_row.add_suffix(Gtk.Image.new_from_icon_name('go-next-symbolic'))
+    display_row.connect('activated', lambda _: launch_settings_panel('display'))
+    display_group.add(display_row)
 
-    search.connect('search-changed', on_search_changed)
-
-    scrolled.set_child(listbox)
-    box.append(scrolled)
+    box.append(display_group)
 
     page.set_child(box)
     return page
 
 
-def make_display_page():
-    """Display config — launches GNOME Settings display panel."""
-    page = Adw.StatusPage(
-        title='Display',
-        description='Optionally configure resolution, orientation and layout.\nClick Done to skip.',
-    )
-
-    group = Adw.PreferencesGroup()
-
-    # Button to open GNOME display settings
-    row = Adw.ActionRow(
-        title='Open Display Settings',
-        subtitle='Arrange displays, set resolution, rotation and scaling',
-    )
-    row.set_activatable(True)
-
-    icon = Gtk.Image.new_from_icon_name('go-next-symbolic')
-    row.add_suffix(icon)
-
-    def on_activated(_row):
-        try:
-            subprocess.Popen(
-                ['gnome-control-center', 'display'],
-                start_new_session=True,
-            )
-        except Exception:
-            pass
-
-    row.connect('activated', on_activated)
-    group.add(row)
-
-    # Hint for CLI users
-    hint = Adw.ActionRow(
-        title='Command line',
-        subtitle='gdctl set --logical-monitor --monitor HDMI-1 --transform 90 --persistent',
-    )
-    hint.add_css_class('property')
-    group.add(hint)
-
-    page.set_child(group)
-    return page
-
-
-def make_player_page():
-    """Player selection — same layout as gnome-initial-setup account page."""
-    page = Adw.StatusPage(
-        title='Player',
-        description='Select the digital signage player for this device.',
-    )
-    page.selected = None
-    page.service = None
-
-    group = Adw.PreferencesGroup()
-    first_check = None
-
-    def on_toggled(check, name, service):
-        if check.get_active():
-            page.selected = name
-            page.service = service
-
-    for name, binary, service, desc, default in PLAYERS:
-        if not os.path.isfile(binary):
-            continue
-
-        row = Adw.ActionRow(title=name, subtitle=desc)
-
-        check = Gtk.CheckButton()
-        if first_check is None:
-            first_check = check
-            if default:
-                check.set_active(True)
-                page.selected = name
-                page.service = service
-        else:
-            check.set_group(first_check)
-
-        check.connect('toggled', on_toggled, name, service)
-        row.add_prefix(check)
-        row.set_activatable_widget(check)
-        group.add(row)
-
-    if page.selected is None and first_check is not None:
-        first_check.set_active(True)
-
-    page.set_child(group)
-    return page
-
-
 def make_cms_page():
-    """CMS configuration — same layout as gnome-initial-setup network page."""
+    """CMS configuration for Arexibo — URL, key, display name."""
     page = Adw.StatusPage(
         title='CMS Connection',
-        description='Enter your Xibo CMS server details.',
+        description='Enter your Xibo CMS server details.\nArexibo requires manual CMS configuration.',
+        icon_name='network-server-symbolic',
     )
 
     box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
@@ -280,6 +215,7 @@ def make_cms_page():
 
 
 def validate_cms(page):
+    """Validate CMS fields. Returns True if valid."""
     url = page.url_row.get_text().strip()
     key = page.key_row.get_text().strip()
 
@@ -296,36 +232,11 @@ def validate_cms(page):
     return True
 
 
-def get_cms_config(page):
-    url = page.url_row.get_text().strip()
-    if not url.endswith('/'):
-        url += '/'
-    key = page.key_row.get_text().strip()
-    name = page.name_row.get_text().strip() or socket.gethostname()
-
-    machine_id = ''
-    try:
-        with open('/etc/machine-id') as f:
-            machine_id = f.read().strip()
-    except OSError:
-        pass
-
-    raw = f'{machine_id}{int(time.time())}{key}'
-    display_id = hashlib.sha256(raw.encode()).hexdigest()[:12]
-
-    return {
-        'address': url,
-        'key': key,
-        'display_id': f'xibo-{display_id}',
-        'display_name': name,
-        'proxy': None,
-    }
-
-
 # ── Window ────────────────────────────────────────────────────
 
+
 class SetupWindow(Adw.ApplicationWindow):
-    """Matches gnome-initial-setup window: header bar + content + nav buttons."""
+    """First-boot setup wizard."""
 
     def __init__(self, app):
         super().__init__(
@@ -334,139 +245,125 @@ class SetupWindow(Adw.ApplicationWindow):
             default_height=550,
         )
 
+        self.player_info = read_setup_result()
+        self.needs_cms = self.player_info.get('player') == 'Arexibo'
+
         toolbar = Adw.ToolbarView()
 
         # Header bar
         header = Adw.HeaderBar()
-        header.set_title_widget(Gtk.Label(label='Xibo Player Setup'))
+        header.set_title_widget(Gtk.Label(label='xiboplayer setup'))
 
         self.back_btn = Gtk.Button(label='Previous')
         self.back_btn.connect('clicked', self._on_back)
         self.back_btn.set_visible(False)
         header.pack_start(self.back_btn)
 
-        self.next_btn = Gtk.Button(label='Next')
+        self.next_btn = Gtk.Button(label='Done' if not self.needs_cms else 'Next')
         self.next_btn.add_css_class('suggested-action')
         self.next_btn.connect('clicked', self._on_next)
         header.pack_end(self.next_btn)
 
         toolbar.add_top_bar(header)
 
-        # Stack for pages (matches gnome-initial-setup's GtkStack with crossfade)
+        # Pages
         self.stack = Gtk.Stack(
             transition_type=Gtk.StackTransitionType.CROSSFADE,
             transition_duration=300,
         )
 
-        self.language_page = make_language_page()
-        self.player_page = make_player_page()
-        self.cms_page = make_cms_page()
-        self.display_page = make_display_page()
+        self.system_page = make_system_page()
+        self.stack.add_named(self.system_page, 'system')
 
-        self.stack.add_named(self.language_page, 'language')
-        self.stack.add_named(self.player_page, 'player')
-        self.stack.add_named(self.cms_page, 'cms')
-        self.stack.add_named(self.display_page, 'display')
-
-        # Page order for navigation
-        self.pages = ['language', 'player', 'cms', 'display']
+        if self.needs_cms:
+            self.cms_page = make_cms_page()
+            self.stack.add_named(self.cms_page, 'cms')
 
         toolbar.set_content(self.stack)
         self.set_content(toolbar)
-        self._update_buttons()
-
-    def _current(self):
-        return self.stack.get_visible_child_name()
-
-    def _is_last(self):
-        return self._current() == 'display'
-
-    def _update_buttons(self):
-        current = self._current()
-        self.back_btn.set_visible(current != 'language')
-        self.next_btn.set_label('Done' if self._is_last() else 'Next')
-
-    def _go(self, name):
-        self.stack.set_visible_child_name(name)
-        self._update_buttons()
 
     def _on_back(self, _btn):
-        current = self._current()
-        idx = self.pages.index(current)
-        if idx > 0:
-            self._go(self.pages[idx - 1])
+        if self.stack.get_visible_child_name() == 'cms':
+            self.stack.set_visible_child_name('system')
+            self.back_btn.set_visible(False)
+            self.next_btn.set_label('Next')
 
     def _on_next(self, _btn):
-        current = self._current()
+        current = self.stack.get_visible_child_name()
 
-        if current == 'language':
-            import threading
-            threading.Thread(target=self._apply_locale, daemon=True).start()
-            self._go('player')
-            return
+        if current == 'system':
+            # Refresh status indicators
+            self.system_page.wifi_row.set_subtitle(get_wifi_status())
+            self.system_page.tz_row.set_subtitle(get_timezone())
+            self.system_page.lang_row.set_subtitle(get_locale())
 
-        if current == 'player':
-            if self.player_page.selected == 'Arexibo':
-                self._go('cms')
+            if self.needs_cms:
+                self.stack.set_visible_child_name('cms')
+                self.back_btn.set_visible(True)
+                self.next_btn.set_label('Done')
             else:
-                self._go('display')
+                self._finish()
             return
 
         if current == 'cms':
             if not validate_cms(self.cms_page):
                 return
-            self._go('display')
-            return
-
-        if current == 'display':
+            self._write_cms_config()
             self._finish()
 
-    def _apply_locale(self):
-        loc = self.language_page.selected_locale
-        try:
-            subprocess.run(
-                ['doas', 'localectl', 'set-locale', f'LANG={loc}'],
-                capture_output=True, timeout=5,
-            )
-        except Exception:
-            pass  # non-fatal on dev machines without doas
+    def _write_cms_config(self):
+        """Write Arexibo cms.json."""
+        url = self.cms_page.url_row.get_text().strip()
+        if not url.endswith('/'):
+            url += '/'
+        key = self.cms_page.key_row.get_text().strip()
+        name = self.cms_page.name_row.get_text().strip() or socket.gethostname()
 
-    def _finish(self):
-        player = self.player_page.selected
-        service = self.player_page.service
-
-        binary_map = {
-            'Electron': '/usr/bin/xiboplayer-electron',
-            'Chromium': '/usr/bin/xiboplayer-chromium',
-            'Arexibo': '/usr/bin/arexibo',
+        config = {
+            'address': url,
+            'key': key,
+            'display_id': generate_display_id(key),
+            'display_name': name,
+            'proxy': None,
         }
-        binary = binary_map.get(player)
-        if binary:
-            subprocess.run(
-                ['doas', 'alternatives', '--set', 'xiboplayer', binary],
-                capture_output=True,
-            )
-
-        if player == 'Arexibo':
-            config = get_cms_config(self.cms_page)
-            os.makedirs(XIBO_DATA_DIR, exist_ok=True)
-            with open(os.path.join(XIBO_DATA_DIR, 'cms.json'), 'w') as f:
-                json.dump(config, f, indent=4)
-
-        if service:
-            subprocess.run(
-                ['systemctl', '--user', 'enable', '--now', service],
-                capture_output=True,
-            )
 
         os.makedirs(XIBO_DATA_DIR, exist_ok=True)
-        with open(os.path.join(XIBO_DATA_DIR, 'setup-result.json'), 'w') as f:
-            json.dump({'player': player, 'service': service}, f)
+        with open(os.path.join(XIBO_DATA_DIR, 'cms.json'), 'w') as f:
+            json.dump(config, f, indent=4)
+
+    def _finish(self):
+        """Activate kiosk mode and log out."""
+        # Activate kiosk session for all future logins
+        subprocess.run(
+            ['doas', os.path.join(KIOSK_DIR, 'xibo-activate-kiosk.sh')],
+            capture_output=True,
+        )
+
+        # Remove autostart so wizard doesn't run again
+        try:
+            os.remove(AUTOSTART_FILE)
+        except OSError:
+            pass
+
+        # Mark gnome-initial-setup as done (belt and suspenders)
+        os.makedirs(os.path.expanduser('~/.config'), exist_ok=True)
+        open(os.path.expanduser('~/.config/gnome-initial-setup-done'), 'a').close()
 
         self.close()
 
+        # Logout — GDM will re-login into kiosk session
+        GLib.timeout_add(500, self._logout)
+
+    def _logout(self):
+        subprocess.run(
+            ['gnome-session-quit', '--logout', '--no-prompt'],
+            capture_output=True,
+        )
+        return False
+
 
 # ── Application ───────────────────────────────────────────────
+
 
 class SetupApp(Adw.Application):
     def __init__(self):

--- a/mkosi-extra/etc/doas.conf
+++ b/mkosi-extra/etc/doas.conf
@@ -2,4 +2,7 @@ permit nopass xibo cmd reboot
 permit nopass xibo cmd shutdown
 permit nopass xibo cmd alternatives
 permit nopass xibo cmd localectl
+permit nopass xibo cmd timedatectl
 permit nopass xibo cmd systemctl args restart NetworkManager
+permit nopass xibo cmd /usr/share/xiboplayer-kiosk/xibo-activate-kiosk.sh
+permit nopass xibo cmd /usr/share/xiboplayer-kiosk/xibo-deactivate-kiosk.sh

--- a/mkosi-extra/usr/share/gnome-initial-setup/vendor.conf
+++ b/mkosi-extra/usr/share/gnome-initial-setup/vendor.conf
@@ -1,0 +1,2 @@
+[pages]
+skip=language;keyboard;network;timezone;privacy;software;account;summary;welcome;password

--- a/mkosi-extra/var/lib/AccountsService/users/xibo
+++ b/mkosi-extra/var/lib/AccountsService/users/xibo
@@ -1,3 +1,3 @@
 [User]
-Session=gnome-kiosk-script-wayland
+Session=gnome
 SystemAccount=false

--- a/rpm/xiboplayer-kiosk.spec
+++ b/rpm/xiboplayer-kiosk.spec
@@ -19,6 +19,9 @@ Requires:       keyd
 Requires:       mesa-va-drivers
 Requires:       libva
 Requires:       alternatives
+Requires:       python3-gobject
+Requires:       libadwaita
+Requires:       gnome-control-center
 Recommends:     xiboplayer-chromium
 Suggests:       xiboplayer-electron
 Suggests:       arexibo
@@ -55,6 +58,9 @@ install -Dm755 kiosk/xibo-show-cms.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/x
 install -Dm644 kiosk/keyd-xibo.conf %{buildroot}%{_sysconfdir}/keyd/xibo.conf
 install -Dm644 kiosk/copr-keyd.repo %{buildroot}%{_sysconfdir}/yum.repos.d/copr-keyd.repo
 install -Dm755 kiosk/xiboplayer-setup.py %{buildroot}%{_datadir}/xiboplayer-kiosk/xiboplayer-setup.py
+install -Dm644 kiosk/xiboplayer-setup.desktop %{buildroot}%{_datadir}/xiboplayer-kiosk/xiboplayer-setup.desktop
+install -Dm755 kiosk/xibo-activate-kiosk.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-activate-kiosk.sh
+install -Dm755 kiosk/xibo-deactivate-kiosk.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-deactivate-kiosk.sh
 
 # Create skel directory for gnome-kiosk-script dispatcher
 install -d %{buildroot}%{_sysconfdir}/skel/.local/bin
@@ -70,11 +76,23 @@ install -m755 kiosk/gnome-kiosk-script.sh %{buildroot}%{_sysconfdir}/skel/.local
 %{_datadir}/xiboplayer-kiosk/xibo-show-ip.sh
 %{_datadir}/xiboplayer-kiosk/xibo-show-cms.sh
 %{_datadir}/xiboplayer-kiosk/xiboplayer-setup.py
+%{_datadir}/xiboplayer-kiosk/xiboplayer-setup.desktop
+%{_datadir}/xiboplayer-kiosk/xibo-activate-kiosk.sh
+%{_datadir}/xiboplayer-kiosk/xibo-deactivate-kiosk.sh
 %{_sysconfdir}/keyd/xibo.conf
 %{_sysconfdir}/yum.repos.d/copr-keyd.repo
 %{_sysconfdir}/skel/.local/bin/gnome-kiosk-script
 
 %changelog
+* Mon Apr 07 2026 Pau Aliagas <linuxnow@gmail.com> - 0.4.19-1
+- Redesign first-boot: normal GNOME session with setup wizard, then kiosk lockdown
+- Setup wizard uses native GNOME panels for WiFi, timezone, language, display
+- Arexibo CMS config in wizard; Chromium/Electron self-configure
+- ISO boot menu with 3 player entries (all players always installed)
+- Ctrl+R reconfigure: reset player config or return to full GNOME wizard
+- Add xiboplayer-setup.desktop, xibo-activate-kiosk.sh, xibo-deactivate-kiosk.sh
+- Add python3-gobject, libadwaita, gnome-control-center as dependencies
+
 * Mon Apr 06 2026 Pau Aliagas <linuxnow@gmail.com> - 0.4.18-1
 - Fix QCOW2 boot (KernelCommandLine=root=gpt-auto), image matrix docs, download links
 


### PR DESCRIPTION
## Summary

- First boot into normal GNOME session with setup wizard autostart
- Wizard launches native GNOME panels for WiFi, Date/Time, Language, Display
- Arexibo gets CMS config fields; Chromium/Electron self-configure
- Wizard finishes → activates kiosk via AccountsService → logout → kiosk forever
- ISO boot menu with 3 player entries (Chromium default, all installed)
- Ctrl+R reconfigure: reset player config OR return to full GNOME wizard

## Test plan

- [ ] Build QCOW2 image and boot in VM
- [ ] Verify first boot shows normal GNOME desktop with wizard
- [ ] Test WiFi button launches gnome-control-center wifi
- [ ] Test Date/Time button launches gnome-control-center datetime
- [ ] Click Done → verify AccountsService switches to kiosk
- [ ] Verify second boot goes directly to kiosk with player
- [ ] Test Ctrl+R reconfigure in kiosk mode
- [ ] Test Ctrl+R full-setup returns to GNOME wizard
- [ ] Test with xibo.profile=arexibo → verify CMS page appears
- [ ] Test with xibo.profile=electron → verify no CMS page

Closes #55