### PR TITLE
security: pin internal reusable workflow references to SHA

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   cleanup:
-    uses: xibo-players/.github/.github/workflows/cleanup-releases.yml@main
+    uses: xibo-players/.github/.github/workflows/cleanup-releases.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       keep-versioned: 3
       keep-dated: 7

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   deb:
-    uses: xibo-players/.github/.github/workflows/build-deb.yml@main
+    uses: xibo-players/.github/.github/workflows/build-deb.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       package-name: xiboplayer-kiosk
       deb-script: 'deb/build-deb.sh'

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-iso.yml@main
+    uses: xibo-players/.github/.github/workflows/build-iso.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       package-name: xiboplayer-kiosk
       kickstart-file: 'kickstart/xiboplayer-kiosk.ks'

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   rpm:
-    uses: xibo-players/.github/.github/workflows/build-rpm.yml@main
+    uses: xibo-players/.github/.github/workflows/build-rpm.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       package-name: xiboplayer-kiosk
       rpm-spec: 'rpm/xiboplayer-kiosk.spec'


### PR DESCRIPTION
Closes #61. Follow-up to #29 / #48. Pins 4 `xibo-players/.github/.github/workflows/*@main` internal reusable workflow references to full commit SHAs. Gap G2 from the 2026-04-09 ecosystem compliance audit.