### PR TITLE
fix(atomic): correct ISO filename in release body URLs (#65)

### DIFF
--- a/.github/workflows/atomic.yml
+++ b/.github/workflows/atomic.yml
@@ -292,6 +292,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.version.outputs.tag }}
+          # ISO filenames use the bare date version, NOT the full tag —
+          # see the "Verify and rename ISO" build step where output is
+          # named "xiboplayer-kiosk-atomic_${VERSION}_{arch}.iso".
+          # Without this separation the release body generates 404 URLs
+          # with the "atomic-" prefix in the filename (issue #65).
+          VERSION: ${{ steps.version.outputs.version }}
           DL: https://images.xiboplayer.org/xiboplayer-kiosk-atomic
         run: |
           NOTES=$(cat <<NOTES_EOF
@@ -303,8 +309,8 @@ jobs:
 
           | Image | Download |
           |-------|----------|
-          | **x86_64 ISO** | [xiboplayer-kiosk-atomic_${TAG}_x86_64.iso](${DL}/${TAG}/xiboplayer-kiosk-atomic_${TAG}_x86_64.iso) |
-          | **aarch64 ISO** | [xiboplayer-kiosk-atomic_${TAG}_aarch64.iso](${DL}/${TAG}/xiboplayer-kiosk-atomic_${TAG}_aarch64.iso) |
+          | **x86_64 ISO** | [xiboplayer-kiosk-atomic_${VERSION}_x86_64.iso](${DL}/${TAG}/xiboplayer-kiosk-atomic_${VERSION}_x86_64.iso) |
+          | **aarch64 ISO** | [xiboplayer-kiosk-atomic_${VERSION}_aarch64.iso](${DL}/${TAG}/xiboplayer-kiosk-atomic_${VERSION}_aarch64.iso) |
           | **Checksums** | [SHA256SUMS](${DL}/${TAG}/SHA256SUMS) |
 
           ## What's included


### PR DESCRIPTION
Closes #65.

## The bug

The `release` step in `.github/workflows/atomic.yml` uses `${TAG}` (e.g. `atomic-20260408`) in the download URLs. But the `Verify and rename ISO` build step names the ISO files using `${VERSION}` (e.g. `20260408`, no prefix).

Result: every atomic release since the `atomic-` tag prefix was added has had broken ISO download links in the release body. The files are uploaded to R2 correctly — only the notes have the wrong URLs.

## Evidence

- Actual file: `https://images.xiboplayer.org/xiboplayer-kiosk-atomic/atomic-20260408/xiboplayer-kiosk-atomic_20260408_x86_64.iso` → HTTP 200 ✓
- Release body URL: `https://images.xiboplayer.org/xiboplayer-kiosk-atomic/atomic-20260408/xiboplayer-kiosk-atomic_atomic-20260408_x86_64.iso` → HTTP 404 ✗

## Fix

Separate `VERSION` (date only) from `TAG` (`atomic-${VERSION}`) in the release body template:
- **Directory path** still uses `${TAG}` (that's the actual R2 upload path)
- **Filename parts** use `${VERSION}` (that's the actual file on disk)

## Test plan

- [ ] Merge this PR, trigger a new atomic release, verify the release body links work end-to-end
- [ ] Optionally: regenerate the existing atomic-20260408 release body with a one-liner to fix it retroactively