### PR TITLE
chore: bump version to 0.4.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.4.20 (2026-04-11)
+
+Version bump. Planned feature scope tracked as GitHub issues for separate implementation:
+
+- **#67** — zenity first-boot menu (XPC/XPE) — direct `nmcli` + `timedatectl`, no GNOME Settings
+- **#68** — iPXE / kernel preseed infrastructure + `xibo.config_url=` JSON fetch + best-available-disk autodetect
+- **#69** — 4-layer power management + GNOME donation popup correction (S6 #370 + S4 #374)
+- **#70** — `xibo-debug-dump` support bundle (Ctrl+D / zenity / labelled USB trigger)
+- **#71** — drop arexibo from default image (keep netinstall opt-in via `xibo.profile=arexibo`)
+- **#72** — pre-anaconda whiptail WiFi TUI for netinstall / iPXE
+- **#73** — USB auto-detect for `setup.json` preseed (2x-USB MSP flow)
+- **#74** — bats test suite + shellcheck CI
+
+Authoritative spec for all items: `xiboplayer-memory/public/plan_consolidated-kiosk-plan-singularity-6-horizon-2026-2-release.md` (1334 lines, hardened through 7 review passes + 2 research reports).
+
+No functional changes in this release — rebuilds images with current main-branch state.
+
 ## 0.4.18 (2026-04-06)
 
 - Fix QCOW2 boot (KernelCommandLine=root=gpt-auto), image matrix docs, download links

--- a/rpm/xiboplayer-kiosk.spec
+++ b/rpm/xiboplayer-kiosk.spec
@@ -1,6 +1,6 @@
 Name:           xiboplayer-kiosk
-Version:        0.4.19
-Release:        2%{?dist}
+Version:        0.4.20
+Release:        1%{?dist}
 Summary:        Kiosk session scripts for Xibo digital signage players
 
 License:        AGPLv3+
@@ -84,6 +84,13 @@ install -m755 kiosk/gnome-kiosk-script.sh %{buildroot}%{_sysconfdir}/skel/.local
 %{_sysconfdir}/skel/.local/bin/gnome-kiosk-script
 
 %changelog
+* Sat Apr 11 2026 Pau Aliagas <linuxnow@gmail.com> - 0.4.20-1
+- Version bump. Planned feature scope tracked as GitHub issues #67-#74
+  (zenity first-boot menu, iPXE preseed + best-available-disk, power-mgmt
+  + donation fix, debug tarball, drop arexibo, pre-anaconda whiptail TUI,
+  USB auto-detect, bats + shellcheck CI). No functional changes in this
+  release — rebuilds images with current main-branch state.
+
 * Mon Apr 07 2026 Pau Aliagas <linuxnow@gmail.com> - 0.4.19-1
 - Redesign first-boot: normal GNOME session with setup wizard, then kiosk lockdown
 - Setup wizard uses native GNOME panels for WiFi, timezone, language, display


### PR DESCRIPTION
## Summary

- Version-only bump: `0.4.19` → `0.4.20` in `rpm/xiboplayer-kiosk.spec`, with a matching `%changelog` entry and new `CHANGELOG.md` block
- **No functional changes** — this release rebuilds images with the current `main` branch state
- The planned feature scope (originally targeted as a jump to v0.5.0) is now **tracked as GitHub issues** for iterative implementation rather than a single large release

## Tracked feature scope (separate PRs to follow)

| Issue | Item |
|---|---|
| #67 | zenity first-boot menu (XPC/XPE) — direct \`nmcli\` + \`timedatectl\`, no GNOME Settings |
| #68 | iPXE / kernel preseed + \`xibo.config_url=\` JSON fetch + best-available-disk autodetect |
| #69 | 4-layer power management + GNOME donation popup correction (S6 #370, S4 #374) |
| #70 | \`xibo-debug-dump\` support bundle (Ctrl+D / zenity / labelled USB trigger) |
| #71 | drop arexibo from default image (keep netinstall opt-in via \`xibo.profile=arexibo\`) |
| #72 | pre-anaconda whiptail WiFi TUI for netinstall / iPXE |
| #73 | USB auto-detect for \`setup.json\` preseed (2x-USB MSP flow) |
| #74 | bats test suite + shellcheck CI |

Authoritative spec for all items: the consolidated plan in \`xiboplayer-memory/public/\` (1334 lines), hardened through 7 review passes (functional x4, security x1, UX x1, senior-architect x1) and 2 research reports (existing kiosk image survey + modern Fedora installer tooling).

## Why not v0.5.0?

Per user directive: *"do not jump to 0.5.0 still, just bump the version. and keep all the planned features as issues"*. Smaller, more bisectable releases; each tracked issue can merge independently.

## Test plan

- [ ] \`rpmbuild -ba rpm/xiboplayer-kiosk.spec\` succeeds with the new version string
- [ ] CI workflows (image.yml, atomic.yml, rpm.yml, deb.yml, qcow2-bootc.yml, ipxe.yml) pass on this branch
- [ ] On merge, new 0.4.20 images are built and published to the usual release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)