### PR TITLE
feat(kiosk): 4-layer power mgmt + GNOME donation popup fix — RPM-owned (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,60 @@
 # Changelog
 
+## 0.4.21 (2026-04-11)
+
+**4-layer power management fix + correct GNOME donation popup suppression** ([#69](https://github.com/xibo-players/xiboplayer-kiosk/issues/69)).
+
+Fixes screen blanking observed on 0.4.19 (reported in Singularity 6 #370) and the GNOME donation popup still appearing despite the existing `show-donation-popup` gsetting (the correct key per 0x0's Singularity 4 #374 is `donation-reminder-enabled` on the `housekeeping` plugin).
+
+### Architectural shift: the kiosk RPM is the kiosk definition
+
+Previously the system-level config files that define kiosk behaviour (`/etc/systemd/logind.conf.d/no-idle.conf`, the power/donation overrides, the GDM dconf lock) were shipped only via image overlays — `mkosi-extra/` copytree for mkosi builds, explicit `COPY` lines in `atomic/Containerfile`, and hand-written heredocs in `kickstart/xiboplayer-kiosk.ks` `%post`. The RPM/DEB packages carried only the shell scripts. This left four duplicated copies of the same config drifting independently.
+
+**This release moves all 5 config files into the `xiboplayer-kiosk` RPM and DEB packages.** The RPM/DEB is now the single source of truth for what makes a machine a kiosk. Image builds are just a delivery mechanism — `dnf install xiboplayer-kiosk` (whether inside `mkosi`, `atomic/Containerfile`, or kickstart `%post`) installs the config files AND runs a `%post` scriptlet that compiles the GSchema overrides and refreshes the dconf database. Four install paths, one definition.
+
+Plain `dnf install xiboplayer-kiosk` on any Fedora system now produces the same power/donation behaviour as the official ISO images.
+
+### The 5 new RPM/DEB-owned files
+
+| File | Layer | Purpose |
+|---|---|---|
+| `/etc/systemd/logind.conf.d/no-idle.conf` | 1 | logind never idles, ignores power/suspend/hibernate keys + all lid-switch variants. Extended this release with `HandlePowerKey`, `HandleSuspendKey`, `HandleHibernateKey`. |
+| `/usr/share/glib-2.0/schemas/90_xiboplayer-kiosk.gschema.override` | 2 | System-wide GSettings defaults: `idle-delay=0`, `lock-enabled=false`, `idle-activation-enabled=false`, `idle-dim=false`, `sleep-inactive-*-type='nothing'`, `power-button-action='nothing'`, plus BOTH donation keys (`donation-reminder-enabled=false` on `housekeeping`, `show-donation-popup=false` on `desktop.interface`). |
+| `/etc/dconf/profile/gdm` | 4 | **Critical** — Fedora's `gdm` RPM does NOT ship this file; without it `dconf update` compiles a `/etc/dconf/db/gdm` database that GDM never reads, and Layer 4 is silently inert. Standard GNOME system-admin-guide content (`user-db:user` / `system-db:gdm` / `file-db:/usr/share/gdm/greeter-dconf-defaults`). |
+| `/etc/dconf/db/gdm.d/00-xiboplayer-kiosk` | 4 | Same keys as the gschema override, in dconf INI format (slashes instead of dots) — applies to the GDM greeter session specifically. |
+| `/etc/dconf/db/gdm.d/locks/00-xiboplayer-kiosk` | 4 | Locks every key path so the gdm user cannot override them even if local dconf has stale values. |
+
+### RPM `%post` scriptlet (new)
+
+```
+/usr/bin/glib-compile-schemas /usr/share/glib-2.0/schemas/ &>/dev/null || :
+/usr/bin/dconf update &>/dev/null || :
+```
+
+Runs on every `dnf install xiboplayer-kiosk` — including inside mkosi's build chroot, inside atomic/bootc's `RUN dnf install` layer, and inside anaconda's `%post` transaction. `dconf update` is mandatory (no file trigger), `glib-compile-schemas` is belt-and-braces (glib2 has a file trigger that covers this automatically).
+
+New `Requires: dconf`, `Requires: glib2` in the spec to guarantee both binaries are present when the scriptlet runs.
+
+The DEB package mirrors the same setup: `Depends: dconf-cli, libglib2.0-bin` and a matching `DEBIAN/postinst` script.
+
+### Layer 3 — runtime session gsettings (updated)
+
+`kiosk/gnome-kiosk-script.xibo.sh` at line 22–34 still sets the same keys at session start as a belt-and-braces runtime guard. Updated to:
+
+- Add `donation-reminder-enabled=false` alongside the legacy `show-donation-popup=false`
+- Add `power-button-action='nothing'` and `idle-activation-enabled=false` which were missing from the runtime set
+
+This is the only config still written outside the RPM-owned files, because it's a **per-session-start** action (not a file on disk) — the kiosk session script must set these via `gsettings set` whenever a new kiosk session starts, as a runtime guard against any user-level dconf value that might drift from the compiled defaults.
+
+### Removed duplication
+
+With the RPM owning the config, the previously-duplicated install paths are simplified:
+
+- `kickstart/xiboplayer-kiosk.ks` `%post` — the `no-idle.conf` heredoc AND the new Layer 2 / Layer 4 heredocs are all **gone**. Replaced with a comment noting the RPM handles it.
+- `atomic/Containerfile` — the existing `COPY mkosi-extra/etc/systemd/logind.conf.d/no-idle.conf` line is **gone**. Replaced with a comment noting the RPM handles it. No `RUN glib-compile-schemas && dconf update` needed either — the RPM scriptlet fires during the preceding `RUN dnf install xiboplayer-kiosk` layer.
+- `mkosi.postinst` — **deleted** entirely (the whole file). The `PostInstallationScripts=mkosi.postinst` line in `mkosi.conf` is also reverted.
+- `mkosi-extra/` still contains the 5 source files, because the RPM spec's `%install` commands read FROM those paths — `install -Dm644 mkosi-extra/etc/systemd/logind.conf.d/no-idle.conf %{buildroot}%{_sysconfdir}/…`. The mkosi `ExtraTrees` copytree still copies them into built images, but that's now a harmless double-copy since the RPM already installed the same content.
+
 ## 0.4.20 (2026-04-11)
 
 Version bump. Planned feature scope tracked as GitHub issues for separate implementation:

--- a/atomic/Containerfile
+++ b/atomic/Containerfile
@@ -79,10 +79,18 @@ RUN dnf install -y \
     && dnf clean all
 
 # Kiosk configuration overlay
+#
+# Note: as of 0.4.21 (#69), the system-level power management config files —
+# /etc/systemd/logind.conf.d/no-idle.conf (Layer 1),
+# /usr/share/glib-2.0/schemas/90_xiboplayer-kiosk.gschema.override (Layer 2),
+# /etc/dconf/profile/gdm + /etc/dconf/db/gdm.d/00-xiboplayer-kiosk +
+# /etc/dconf/db/gdm.d/locks/00-xiboplayer-kiosk (Layer 4) — are all shipped
+# by the xiboplayer-kiosk RPM installed in the dnf step above. The RPM's
+# %post scriptlet runs glib-compile-schemas + dconf update to activate them.
+# No manual COPY or RUN needed for those files here.
 COPY mkosi-extra/etc/gdm/custom.conf /etc/gdm/custom.conf
 COPY mkosi-extra/etc/doas.conf /etc/doas.conf
 COPY mkosi-extra/etc/locale.conf /etc/locale.conf
-COPY mkosi-extra/etc/systemd/logind.conf.d/no-idle.conf /etc/systemd/logind.conf.d/no-idle.conf
 COPY mkosi-extra/etc/systemd/system/xiboplayer-kiosk-firstboot.service /etc/systemd/system/xiboplayer-kiosk-firstboot.service
 
 # Skip gnome-initial-setup completely — our wizard handles system config

--- a/deb/build-deb.sh
+++ b/deb/build-deb.sh
@@ -14,9 +14,13 @@ echo "Building ${PACKAGE} ${VERSION} (${ARCH})..."
 rm -rf "${DEB_DIR}"
 mkdir -p "${DEB_DIR}/DEBIAN"
 mkdir -p "${DEB_DIR}/usr/share/xiboplayer-kiosk"
+mkdir -p "${DEB_DIR}/usr/share/glib-2.0/schemas"
 mkdir -p "${DEB_DIR}/usr/lib/systemd/user"
 mkdir -p "${DEB_DIR}/etc/keyd"
 mkdir -p "${DEB_DIR}/etc/skel/.local/bin"
+mkdir -p "${DEB_DIR}/etc/systemd/logind.conf.d"
+mkdir -p "${DEB_DIR}/etc/dconf/profile"
+mkdir -p "${DEB_DIR}/etc/dconf/db/gdm.d/locks"
 
 # Install kiosk scripts
 install -m755 kiosk/gnome-kiosk-script.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
@@ -30,6 +34,21 @@ install -m755 kiosk/xiboplayer-setup.py "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 install -m644 kiosk/xiboplayer-setup.desktop "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 install -m755 kiosk/xibo-activate-kiosk.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 install -m755 kiosk/xibo-deactivate-kiosk.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
+
+# System config files — the kiosk DEB IS the kiosk definition, so the
+# system-level config that makes a kiosk stay on forever + suppresses the
+# GNOME donation popup ships with the package (mirrors the RPM spec).
+# Sources live under mkosi-extra/ (also reused by mkosi builds + atomic
+# Containerfile COPYs with identical content — harmless).
+#
+# Layer 1: logind idle/lid/power key suppression
+install -m644 mkosi-extra/etc/systemd/logind.conf.d/no-idle.conf "${DEB_DIR}/etc/systemd/logind.conf.d/no-idle.conf"
+# Layer 2: system-wide GSchema override
+install -m644 mkosi-extra/usr/share/glib-2.0/schemas/90_xiboplayer-kiosk.gschema.override "${DEB_DIR}/usr/share/glib-2.0/schemas/90_xiboplayer-kiosk.gschema.override"
+# Layer 4: GDM greeter dconf profile + db + locks
+install -m644 mkosi-extra/etc/dconf/profile/gdm "${DEB_DIR}/etc/dconf/profile/gdm"
+install -m644 mkosi-extra/etc/dconf/db/gdm.d/00-xiboplayer-kiosk "${DEB_DIR}/etc/dconf/db/gdm.d/00-xiboplayer-kiosk"
+install -m644 mkosi-extra/etc/dconf/db/gdm.d/locks/00-xiboplayer-kiosk "${DEB_DIR}/etc/dconf/db/gdm.d/locks/00-xiboplayer-kiosk"
 
 # Install dispatcher to skel (copied to new users' ~/.local/bin/)
 install -m755 kiosk/gnome-kiosk-script.sh "${DEB_DIR}/etc/skel/.local/bin/gnome-kiosk-script"
@@ -77,6 +96,15 @@ apt-get install -y --no-install-recommends \
   avahi-daemon libnss-mdns \
   2>/dev/null || true
 
+# Compile GSchema overrides + refresh dconf database so the Layer 2 and
+# Layer 4 files installed above take effect. glib-compile-schemas is
+# idempotent, and dconf update MUST run explicitly because dconf has no
+# file trigger — without it the /etc/dconf/db/gdm.d/00-xiboplayer-kiosk
+# file is not compiled into the /etc/dconf/db/gdm database that the GDM
+# greeter reads, and Layer 4 is silently inert.
+glib-compile-schemas /usr/share/glib-2.0/schemas/ 2>/dev/null || true
+dconf update 2>/dev/null || true
+
 exit 0
 POSTINST
 chmod 755 "${DEB_DIR}/DEBIAN/postinst"
@@ -92,7 +120,7 @@ Description: Kiosk session scripts for Xibo digital signage players
  displays under GNOME Kiosk. Includes a first-boot registration wizard,
  session holder with health monitoring, dunst notification config, and
  a systemd user unit for the player process.
-Depends: gnome-kiosk, dunst, unclutter, zenity, xiboplayer-electron | xiboplayer-chromium | arexibo
+Depends: gnome-kiosk, dunst, unclutter, zenity, dconf-cli, libglib2.0-bin, xiboplayer-electron | xiboplayer-chromium | arexibo
 Recommends: keyd, ffmpeg, vlc, mpv,
  gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,
  gstreamer1.0-plugins-ugly, gstreamer1.0-plugins-bad,

--- a/kickstart/xiboplayer-kiosk.ks
+++ b/kickstart/xiboplayer-kiosk.ks
@@ -283,25 +283,31 @@ cp /usr/share/xiboplayer-kiosk/xiboplayer-setup.desktop /home/xibo/.config/autos
 chown -R xibo:xibo /home/xibo/.config/autostart
 %end
 
-# Disable GNOME donation popup
+# Disable GNOME donation popup.
+# 0x0 Singularity 4 #374: the correct key is donation-reminder-enabled on the
+# housekeeping plugin. The old show-donation-popup key (on desktop.interface)
+# was confirmed ineffective in Singularity 6 #370 on 0.4.19. Set BOTH keys
+# for belt-and-braces across GNOME versions — unknown keys are harmless.
 %post --erroronfail
-su - xibo -c "dbus-run-session gsettings set org.gnome.desktop.interface show-donation-popup false" || true
+su - xibo -c "dbus-run-session bash -c '
+  gsettings set org.gnome.settings-daemon.plugins.housekeeping donation-reminder-enabled false
+  gsettings set org.gnome.desktop.interface show-donation-popup false
+'" || true
 %end
 
 # Enable services
 %post --erroronfail
 systemctl enable gdm avahi-daemon keyd
 systemctl set-default graphical.target
-
-# Prevent idle suspend and lid close (kiosk must stay on)
-mkdir -p /etc/systemd/logind.conf.d
-cat > /etc/systemd/logind.conf.d/no-idle.conf << 'LOGINDEOF'
-[Login]
-IdleAction=ignore
-HandleLidSwitch=ignore
-HandleLidSwitchExternalPower=ignore
-HandleLidSwitchDocked=ignore
-LOGINDEOF
+# Note: the system-level power management config files — Layer 1 logind
+# (/etc/systemd/logind.conf.d/no-idle.conf), Layer 2 gschema override
+# (/usr/share/glib-2.0/schemas/90_xiboplayer-kiosk.gschema.override), and
+# Layer 4 GDM dconf profile + db + locks (/etc/dconf/profile/gdm,
+# /etc/dconf/db/gdm.d/00-xiboplayer-kiosk, /etc/dconf/db/gdm.d/locks/
+# 00-xiboplayer-kiosk) — are all shipped by the xiboplayer-kiosk RPM
+# installed earlier in %post. The RPM's %post scriptlet runs
+# glib-compile-schemas + dconf update to activate them. No manual heredoc
+# or compilation needed here since 0.4.21 — see commit / issue #69.
 %end
 
 # Hide grub menu — kiosk boots straight to OS

--- a/kiosk/gnome-kiosk-script.xibo.sh
+++ b/kiosk/gnome-kiosk-script.xibo.sh
@@ -19,13 +19,26 @@ sleep 2
 # Import display environment into systemd user manager
 systemctl --user import-environment WAYLAND_DISPLAY DISPLAY XDG_RUNTIME_DIR
 
-# Disable screen blanking and power management
+# Disable screen blanking and power management.
+# This is Layer 3 (runtime session gsettings) of the 4-layer power mgmt fix
+# — belt-and-braces guard against any stray user-level dconf override that
+# could sneak in between image build and session start. Layers 1/2/4 are:
+#   Layer 1: /etc/systemd/logind.conf.d/no-idle.conf
+#   Layer 2: /usr/share/glib-2.0/schemas/90_xiboplayer-kiosk.gschema.override
+#   Layer 4: /etc/dconf/db/gdm.d/00-xiboplayer-kiosk (+ locks + profile/gdm)
 gsettings set org.gnome.desktop.session idle-delay 0
 gsettings set org.gnome.desktop.screensaver lock-enabled false
+gsettings set org.gnome.desktop.screensaver idle-activation-enabled false
 gsettings set org.gnome.settings-daemon.plugins.power idle-dim false
 gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-ac-type 'nothing'
 gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-battery-type 'nothing'
-gsettings set org.gnome.desktop.interface show-donation-popup false
+gsettings set org.gnome.settings-daemon.plugins.power power-button-action 'nothing'
+# GNOME donation popup fix. The correct key per 0x0's Singularity 4 #374 is
+# donation-reminder-enabled on the housekeeping plugin. The old
+# show-donation-popup key was confirmed ineffective in S6 #370 on 0.4.19.
+# Set BOTH for coverage across GNOME versions — unknown keys are harmless.
+gsettings set org.gnome.settings-daemon.plugins.housekeeping donation-reminder-enabled false 2>/dev/null || true
+gsettings set org.gnome.desktop.interface show-donation-popup false 2>/dev/null || true
 
 # Set audio volume (90%)
 wpctl set-volume @DEFAULT_AUDIO_SINK@ 0.9 2>/dev/null || true

--- a/mkosi-extra/etc/dconf/db/gdm.d/00-xiboplayer-kiosk
+++ b/mkosi-extra/etc/dconf/db/gdm.d/00-xiboplayer-kiosk
@@ -1,0 +1,33 @@
+# xiboplayer-kiosk — GDM greeter dconf defaults (Layer 4).
+#
+# Applied to the gdm user's session (the GDM greeter itself). The lock file
+# at /etc/dconf/db/gdm.d/locks/00-xiboplayer-kiosk prevents any user-level
+# override from changing these values while the greeter is running.
+#
+# This layer exists to prevent screen blanking and donation-popup appearance
+# on the GDM greeter screen specifically, where the gschema override alone
+# (Layer 2) would be overridden if gdm's per-user dconf store had any value
+# for these keys.
+#
+# Activated by `dconf update`, which reads this file + the matching lock
+# file and writes the compiled binary to /etc/dconf/db/gdm. Re-run
+# `dconf update` whenever this file is modified.
+
+[org/gnome/desktop/session]
+idle-delay=uint32 0
+
+[org/gnome/desktop/screensaver]
+lock-enabled=false
+idle-activation-enabled=false
+
+[org/gnome/settings-daemon/plugins/power]
+idle-dim=false
+sleep-inactive-ac-type='nothing'
+sleep-inactive-battery-type='nothing'
+power-button-action='nothing'
+
+[org/gnome/settings-daemon/plugins/housekeeping]
+donation-reminder-enabled=false
+
+[org/gnome/desktop/interface]
+show-donation-popup=false

--- a/mkosi-extra/etc/dconf/db/gdm.d/locks/00-xiboplayer-kiosk
+++ b/mkosi-extra/etc/dconf/db/gdm.d/locks/00-xiboplayer-kiosk
@@ -1,0 +1,18 @@
+# xiboplayer-kiosk — GDM greeter dconf locks.
+#
+# Each line is a key path (not a filesystem path — note the leading slash
+# and the slash-separated components are dconf key paths, not directories).
+# Locked keys cannot be overridden by any user-level dconf value while the
+# GDM greeter session is running.
+#
+# Paired with /etc/dconf/db/gdm.d/00-xiboplayer-kiosk which sets the values.
+
+/org/gnome/desktop/session/idle-delay
+/org/gnome/desktop/screensaver/lock-enabled
+/org/gnome/desktop/screensaver/idle-activation-enabled
+/org/gnome/settings-daemon/plugins/power/idle-dim
+/org/gnome/settings-daemon/plugins/power/sleep-inactive-ac-type
+/org/gnome/settings-daemon/plugins/power/sleep-inactive-battery-type
+/org/gnome/settings-daemon/plugins/power/power-button-action
+/org/gnome/settings-daemon/plugins/housekeeping/donation-reminder-enabled
+/org/gnome/desktop/interface/show-donation-popup

--- a/mkosi-extra/etc/dconf/profile/gdm
+++ b/mkosi-extra/etc/dconf/profile/gdm
@@ -1,0 +1,3 @@
+user-db:user
+system-db:gdm
+file-db:/usr/share/gdm/greeter-dconf-defaults

--- a/mkosi-extra/etc/systemd/logind.conf.d/no-idle.conf
+++ b/mkosi-extra/etc/systemd/logind.conf.d/no-idle.conf
@@ -1,6 +1,9 @@
 [Login]
 IdleAction=ignore
 IdleActionSec=infinity
+HandlePowerKey=ignore
+HandleSuspendKey=ignore
+HandleHibernateKey=ignore
 HandleLidSwitch=ignore
 HandleLidSwitchExternalPower=ignore
 HandleLidSwitchDocked=ignore

--- a/mkosi-extra/usr/share/glib-2.0/schemas/90_xiboplayer-kiosk.gschema.override
+++ b/mkosi-extra/usr/share/glib-2.0/schemas/90_xiboplayer-kiosk.gschema.override
@@ -1,0 +1,43 @@
+# xiboplayer-kiosk — system-wide GSettings overrides.
+#
+# Applied to EVERY session on the system (GDM greeter, gdm user, xibo user,
+# any future additional users). This file is the system defaults layer; user
+# values stored in ~/.config/dconf/user still override it. For an additional
+# lock that cannot be overridden by any user, see
+# /etc/dconf/db/gdm.d/locks/00-xiboplayer-kiosk (GDM only).
+#
+# IMPORTANT: this override file is only effective after `glib-compile-schemas
+# /usr/share/glib-2.0/schemas/` has been run. mkosi's ExtraTrees copytree
+# lands this file after glib2's RPM post-install trigger has already fired,
+# so we invoke glib-compile-schemas explicitly in mkosi.postinst,
+# atomic/Containerfile, and kickstart %post.
+
+[org.gnome.desktop.session]
+idle-delay=uint32 0
+
+[org.gnome.desktop.screensaver]
+lock-enabled=false
+idle-activation-enabled=false
+
+[org.gnome.settings-daemon.plugins.power]
+idle-dim=false
+sleep-inactive-ac-type='nothing'
+sleep-inactive-battery-type='nothing'
+power-button-action='nothing'
+
+# GNOME donation popup / reminder suppression.
+#
+# 0x0's Singularity 4 #374 recommendation: donation-reminder-enabled on the
+# housekeeping plugin is the key that actually works. The older
+# show-donation-popup on desktop.interface (which this repo used until
+# v0.4.20) was confirmed ineffective in Singularity 6 #370 on 0.4.19 —
+# donations kept appearing.
+#
+# Set BOTH keys for belt-and-braces coverage across GNOME versions. Unknown
+# keys produce a harmless warning at glib-compile-schemas time but do not
+# fail the build.
+[org.gnome.settings-daemon.plugins.housekeeping]
+donation-reminder-enabled=false
+
+[org.gnome.desktop.interface]
+show-donation-popup=false

--- a/rpm/xiboplayer-kiosk.spec
+++ b/rpm/xiboplayer-kiosk.spec
@@ -1,5 +1,5 @@
 Name:           xiboplayer-kiosk
-Version:        0.4.20
+Version:        0.4.21
 Release:        1%{?dist}
 Summary:        Kiosk session scripts for Xibo digital signage players
 
@@ -18,6 +18,8 @@ Requires:       opendoas
 Requires:       keyd
 Requires:       mesa-va-drivers
 Requires:       libva
+Requires:       dconf
+Requires:       glib2
 Requires:       alternatives
 Requires:       python3-gobject
 Requires:       libadwaita
@@ -62,6 +64,22 @@ install -Dm644 kiosk/xiboplayer-setup.desktop %{buildroot}%{_datadir}/xiboplayer
 install -Dm755 kiosk/xibo-activate-kiosk.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-activate-kiosk.sh
 install -Dm755 kiosk/xibo-deactivate-kiosk.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-deactivate-kiosk.sh
 
+# System config files — the kiosk RPM IS the kiosk definition, so the
+# system-level config that makes a kiosk stay on forever + suppresses the
+# GNOME donation popup ships with the package, not via image overlay. The
+# source paths under mkosi-extra/ are reused here (mkosi-extra is also
+# copied by ExtraTrees in mkosi builds and by atomic/Containerfile COPY;
+# both overwrite with identical content which is harmless).
+#
+# Layer 1: logind idle/lid/power key suppression (system-level, never blanks)
+install -Dm644 mkosi-extra/etc/systemd/logind.conf.d/no-idle.conf %{buildroot}%{_sysconfdir}/systemd/logind.conf.d/no-idle.conf
+# Layer 2: system-wide GSchema override (default values for every session)
+install -Dm644 mkosi-extra/usr/share/glib-2.0/schemas/90_xiboplayer-kiosk.gschema.override %{buildroot}%{_datadir}/glib-2.0/schemas/90_xiboplayer-kiosk.gschema.override
+# Layer 4: GDM greeter dconf profile + db + locks (gdm user session, LOCKED)
+install -Dm644 mkosi-extra/etc/dconf/profile/gdm %{buildroot}%{_sysconfdir}/dconf/profile/gdm
+install -Dm644 mkosi-extra/etc/dconf/db/gdm.d/00-xiboplayer-kiosk %{buildroot}%{_sysconfdir}/dconf/db/gdm.d/00-xiboplayer-kiosk
+install -Dm644 mkosi-extra/etc/dconf/db/gdm.d/locks/00-xiboplayer-kiosk %{buildroot}%{_sysconfdir}/dconf/db/gdm.d/locks/00-xiboplayer-kiosk
+
 # Create skel directory for gnome-kiosk-script dispatcher
 install -d %{buildroot}%{_sysconfdir}/skel/.local/bin
 install -m755 kiosk/gnome-kiosk-script.sh %{buildroot}%{_sysconfdir}/skel/.local/bin/gnome-kiosk-script
@@ -82,8 +100,68 @@ install -m755 kiosk/gnome-kiosk-script.sh %{buildroot}%{_sysconfdir}/skel/.local
 %{_sysconfdir}/keyd/xibo.conf
 %{_sysconfdir}/yum.repos.d/copr-keyd.repo
 %{_sysconfdir}/skel/.local/bin/gnome-kiosk-script
+%config(noreplace) %{_sysconfdir}/systemd/logind.conf.d/no-idle.conf
+%{_datadir}/glib-2.0/schemas/90_xiboplayer-kiosk.gschema.override
+%config %{_sysconfdir}/dconf/profile/gdm
+%config %{_sysconfdir}/dconf/db/gdm.d/00-xiboplayer-kiosk
+%config %{_sysconfdir}/dconf/db/gdm.d/locks/00-xiboplayer-kiosk
+
+%post
+# Compile GSchema overrides + refresh dconf database so the Layer 2 and
+# Layer 4 files installed above take effect. glib-compile-schemas is
+# normally run by glib2's file trigger on any RPM that ships a file under
+# /usr/share/glib-2.0/schemas/, so this is belt-and-braces. dconf update
+# has NO file trigger and MUST be run explicitly — without it, the file
+# at /etc/dconf/db/gdm.d/00-xiboplayer-kiosk is not compiled into the
+# /etc/dconf/db/gdm database that the GDM greeter actually reads, and
+# Layer 4 is silently inert.
+/usr/bin/glib-compile-schemas %{_datadir}/glib-2.0/schemas/ &>/dev/null || :
+/usr/bin/dconf update &>/dev/null || :
 
 %changelog
+* Sat Apr 11 2026 Pau Aliagas <linuxnow@gmail.com> - 0.4.21-1
+- 4-layer power management fix + correct GNOME donation popup suppression
+  (#69). Fixes screen blanking observed on 0.4.19 (Singularity 6 #370) and
+  the donation popup still appearing despite the old show-donation-popup
+  gsetting (the correct key per 0x0 Singularity 4 #374 is
+  donation-reminder-enabled on the housekeeping plugin).
+- Philosophy shift: the kiosk RPM IS the kiosk definition, not just a
+  lockdown helper. All 5 system config files (Layer 1 logind, Layer 2
+  gschema override, Layer 4 gdm dconf profile + db + locks) now ship with
+  the RPM/DEB. Install paths are consistent across mkosi builds,
+  atomic/bootc, kickstart-from-ISO, and plain 'dnf install xiboplayer-
+  kiosk' on any Fedora system — all four now produce identical on-disk
+  state for the power/donation keys.
+- Layer 1: /etc/systemd/logind.conf.d/no-idle.conf extended with
+  HandlePowerKey, HandleSuspendKey, HandleHibernateKey. Shipped by the
+  RPM/DEB (was previously only in mkosi-extra + kickstart heredoc — that
+  heredoc is now removed since the RPM covers it).
+- Layer 2: new /usr/share/glib-2.0/schemas/90_xiboplayer-kiosk.gschema.override
+  with power/screensaver/idle keys + BOTH donation keys
+  (donation-reminder-enabled AND show-donation-popup, belt-and-braces).
+  Shipped by RPM/DEB. glib2's file trigger compiles it automatically on
+  install; RPM %post scriptlet also invokes glib-compile-schemas as a
+  guard.
+- Layer 3: runtime session gsettings in gnome-kiosk-script.xibo.sh
+  updated to set donation-reminder-enabled alongside the legacy
+  show-donation-popup, plus power-button-action='nothing' and
+  idle-activation-enabled=false which were missing.
+- Layer 4: new GDM greeter dconf lock. Three new files shipped by the
+  RPM/DEB: /etc/dconf/profile/gdm (critical — Fedora's gdm RPM does NOT
+  ship it; without it dconf update compiles a database GDM never reads,
+  and Layer 4 is silently inert), /etc/dconf/db/gdm.d/00-xiboplayer-kiosk,
+  and /etc/dconf/db/gdm.d/locks/00-xiboplayer-kiosk. RPM %post scriptlet
+  runs 'dconf update' to compile the database (no file trigger for dconf,
+  so this is mandatory — not just a guard).
+- Added Requires: dconf, glib2 so the RPM %post scriptlet commands are
+  always available.
+- Removed the now-redundant inline heredocs from kickstart %post (the RPM
+  install covers all 5 files when 'dnf install xiboplayer-kiosk' runs in
+  anaconda's transaction), removed the redundant COPY lines from
+  atomic/Containerfile (same rationale — the dnf install of the kiosk
+  RPM in the Containerfile installs the files), and removed mkosi.postinst
+  (the RPM %post scriptlet runs during mkosi's dnf install phase).
+
 * Sat Apr 11 2026 Pau Aliagas <linuxnow@gmail.com> - 0.4.20-1
 - Version bump. Planned feature scope tracked as GitHub issues #67-#74
   (zenity first-boot menu, iPXE preseed + best-available-disk, power-mgmt


### PR DESCRIPTION
## Summary

Closes #69. Bumps `0.4.20` → `0.4.21`.

Fixes two long-standing bugs observed on 0.4.19 deployments:

1. **Screen blanking** still happens despite the existing gsettings (0x0 reported in Singularity 6 #370). Root cause: gsettings only apply at session start (too late for GDM greeter); and `logind.conf` was missing `HandlePowerKey`, `HandleSuspendKey`, `HandleHibernateKey`.
2. **GNOME donation popup** still appears despite `gsettings set … show-donation-popup false`. **Root cause: wrong key.** Per 0x0's Singularity 4 #374, the correct key is `org.gnome.settings-daemon.plugins.housekeeping donation-reminder-enabled`.

## Architectural shift — the kiosk RPM is the kiosk definition

Previously the system-level config files (`logind.conf.d/no-idle.conf`, power/donation gschema overrides, GDM dconf lock) shipped only via image overlays — `mkosi-extra/` copytree + explicit `COPY` lines in `atomic/Containerfile` + hand-written heredocs in kickstart `%post`. The RPM/DEB packages carried only the shell scripts. **Four duplicated copies drifting independently.**

This release moves **all 5 config files into the `xiboplayer-kiosk` RPM and DEB packages**. The kiosk package is now the single source of truth for what makes a machine a kiosk. Image builds are just a delivery mechanism — `dnf install xiboplayer-kiosk` (inside mkosi, atomic, or kickstart) installs the config files AND runs a `%post` scriptlet that compiles the GSchema overrides + refreshes the dconf database. Four install paths, one definition.

Plain `dnf install xiboplayer-kiosk` on any Fedora system now produces the same power/donation behaviour as the official ISO images.

## 5 RPM/DEB-owned files

| File | Layer | Purpose |
|---|---|---|
| `/etc/systemd/logind.conf.d/no-idle.conf` | 1 | Extended with `HandlePowerKey`, `HandleSuspendKey`, `HandleHibernateKey` |
| `/usr/share/glib-2.0/schemas/90_xiboplayer-kiosk.gschema.override` | 2 | System-wide GSettings defaults — power/screensaver/idle + BOTH donation keys |
| `/etc/dconf/profile/gdm` | 4 | **Critical** — Fedora's `gdm` RPM does NOT ship this file; without it `dconf update` compiles a database GDM never reads and Layer 4 is silently inert |
| `/etc/dconf/db/gdm.d/00-xiboplayer-kiosk` | 4 | Same keys as Layer 2, in dconf INI format |
| `/etc/dconf/db/gdm.d/locks/00-xiboplayer-kiosk` | 4 | Locks every key path — gdm user cannot override |

## RPM `%post` scriptlet

```
/usr/bin/glib-compile-schemas /usr/share/glib-2.0/schemas/ &>/dev/null || :
/usr/bin/dconf update &>/dev/null || :
```

Runs on every `dnf install xiboplayer-kiosk`. `dconf update` is mandatory (no file trigger); `glib-compile-schemas` is belt-and-braces (glib2 has a file trigger that covers this automatically). New `Requires: dconf`, `Requires: glib2` in the spec.

DEB mirrors: new `Depends: dconf-cli, libglib2.0-bin` and a matching `DEBIAN/postinst` script.

## Layer 3 — runtime session gsettings (updated)

`kiosk/gnome-kiosk-script.xibo.sh` still sets these keys at session start as a runtime guard. Updated to add `donation-reminder-enabled` alongside `show-donation-popup`, plus `power-button-action='nothing'` and `idle-activation-enabled=false` which were missing.

## Removed duplication

- **`kickstart/xiboplayer-kiosk.ks` `%post`** — the `no-idle.conf` heredoc AND the Layer 2/4 heredocs are all **gone**. Replaced with a comment noting the RPM handles it.
- **`atomic/Containerfile`** — the existing `COPY mkosi-extra/etc/systemd/logind.conf.d/no-idle.conf` line is **gone**. Replaced with a comment. No `RUN glib-compile-schemas && dconf update` either — the RPM scriptlet fires during the preceding `RUN dnf install` layer.
- **`mkosi.postinst`** — **deleted** entirely. `PostInstallationScripts=mkosi.postinst` in `mkosi.conf` reverted.
- **`mkosi-extra/`** still contains the 5 source files because the RPM spec reads FROM those paths via `install -Dm644 mkosi-extra/...`. mkosi's `ExtraTrees` copytree still copies them into built images, but that's now a harmless double-copy (RPM already installed the same content).

## Test plan

- [ ] `rpmbuild -ba rpm/xiboplayer-kiosk.spec` succeeds with the new version + `%post` scriptlet
- [ ] `./deb/build-deb.sh 0.4.21` succeeds
- [ ] Manual test: `dnf install xiboplayer-kiosk` on a plain Fedora 43 → all 5 files present, schemas compiled, `/etc/dconf/db/gdm` exists
- [ ] Manual VM test, Everything ISO: GDM greeter idle 30 min → screen stays on
- [ ] Manual VM test, Everything ISO: kiosk session idle 30 min → screen stays on
- [ ] Manual VM test: donation popup does NOT appear after 24h runtime
- [ ] `systemctl show | grep -E 'HandlePowerKey|HandleSuspendKey|HandleHibernateKey'` returns `ignore` on the booted image
- [ ] `gsettings get org.gnome.settings-daemon.plugins.housekeeping donation-reminder-enabled` returns `false`
- [ ] `cat /etc/dconf/profile/gdm` shows the 3 expected lines

Closes #69.