### PR TITLE
feat(kiosk): iPXE preseed infrastructure + best-available-disk (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## 0.4.22 (2026-04-11)
+
+**iPXE / kernel preseed infrastructure + best-available-disk autodetect** ([#68](https://github.com/xibo-players/xiboplayer-kiosk/issues/68)).
+
+Foundation layer for unattended and partially-attended kiosk deployment. Establishes `/etc/xiboplayer-preseed.env` as the single source of truth for preseeded values, consumed by the zenity first-boot menu (#67), the pre-anaconda whiptail TUI (#72), and the USB auto-detect scanner (#73).
+
+### 4-layer precedence (most specific wins)
+
+```
+Layer 0  — baked-in defaults (profile=chromium if nothing given)
+Layer 1  — xibo.config_url=https://…/setup.json (curl+jq in %post)
+Layer 2  — USB /setup.json (reserved for #73)
+Layer 3  — per-field xibo.*= kernel params (this PR, overrides above)
+Layer 4  — interactive zenity menu (reserved for #67)
+```
+
+### Supported `xibo.*` kernel params
+
+`profile`, `config_url`, `cms_url`, `cms_key`, `display_name`, `timezone`, `locale`, `wifi_ssid`, `wifi_psk`, `ssh_pubkey`.
+
+### New files
+
+- **`kiosk/xibo-set-wifi.sh`** — NetworkManager keyfile writer. Writes `/etc/NetworkManager/system-connections/<SSID>.nmconnection` at `0600 root:root` instead of calling `nmcli dev wifi connect … password …`, closing the brief `/proc/<pid>/cmdline` PSK leak. Shipped by the RPM (`%install` + `%files` entries) and DEB (`install` line in `build-deb.sh`). Permitted via doas for the xibo user in both `mkosi-extra/etc/doas.conf` and the kickstart doas heredoc.
+  - Input validation rejects control characters (newline/tab/null) and NM INI section headers in both SSID and PSK — prevents fake `[wifi-security]` section injection via crafted PSK values.
+  - SSID filename sanitisation via `tr -c '[:alnum:]._-' '_'` — path traversal attempts become harmless underscore runs.
+  - Authoritative source of `_validate_nm_string`: the same function will be copied verbatim into `kickstart/xibo-wifi-tui.sh` when #72 lands. bats test at `tests/unit/set-wifi.bats` (#74) will enforce byte-identical keyfile output between the two copies.
+
+### Kickstart `%post` additions
+
+- Parses every `xibo.*=` token on `/proc/cmdline`, skipping `xibo.config_url` (that's the Layer 1 fetch instruction, not a value to store).
+- If `xibo.config_url=` present: `curl --silent --fail --max-time 30` + `jq` with an **inline allowlist regex** (`^[A-Za-z0-9._/@:+=\- ]+$`) that rejects shell metacharacters (`$`, backtick, `;`, `&`, `|`, `>`, `<`, `\`, newline) **before** values are written to `preseed.env`. Keeps the file safe even though it's never `source`d.
+- `_preseed_get()` helper extracts values via `grep | cut` — the preseed file is **never** sourced with `.`, closing the shell-parser attack surface.
+- Applies system-level values immediately: `timedatectl set-timezone`, `localectl set-locale LANG=…`, `xibo-set-wifi.sh <SSID> <PSK>` (root, no doas needed in %post), and the `xibo.ssh_pubkey=` pubkey → `/home/xibo/.ssh/authorized_keys` + `systemctl enable sshd.service` dance.
+- `xibo.ssh_pubkey=` is **URL-encoded** on the kernel cmdline (`%20` for space) to survive quoting. Example: `xibo.ssh_pubkey=ssh-ed25519%20AAAAC3…%20operator@msp`. Decoded back to spaces before writing `authorized_keys`.
+
+### `%pre` — best-available-disk autodetect rewrite
+
+Replaces the previous "first non-removable ≥8 GB" walk with a ranked "largest in best-preferred bus class" heuristic:
+
+1. Preference order: **NVMe > virtio > SATA**. Stops at the first class with any match — doesn't mix candidates across classes.
+2. Within the winning class, picks the **largest** qualifying disk.
+3. Removable devices (USB sticks, CD-ROMs, SD cards via `usb-storage`) skipped via `/sys/block/*/removable == 1`.
+4. Disks < 8 GB skipped (too small for a kiosk image).
+5. **Logs every candidate** considered (name + size + rotational + class) to `/tmp/disk-autodetect.log` so the anaconda install log shows the full selection trail. Previous version only logged the winner.
+6. Fallback to `DISK=sda` if nothing qualifies — anaconda still gets a valid `/tmp/disk-config` to `%include`.
+
+### Security notes
+
+- `xibo.config_url=` values should use **path-based tokens** (e.g. `https://ops.example.com/k/a8f2c9d1b4e7.json`) rather than inline `user:pass@host` credentials. The full URL is captured in `/proc/cmdline` AND in the anaconda install logs (`/root/anaconda-ks.log`, `/var/log/anaconda/*`) — path-based secrets are rotatable without touching the installed machine; Basic Auth credentials in the URL are not.
+- The jq allowlist regex is a defence-in-depth layer: even if a future maintainer accidentally introduces `source /etc/xiboplayer-preseed.env` elsewhere, the values are already free of shell metacharacters thanks to this filter.
+
+### Packages added to kickstart `%packages`
+
+- `jq` — required by the `xibo.config_url=` fetch pipeline and by #73's USB `setup.json` scanner. Lightweight (~1 MB), no weak deps.
+- `openssh-server` — installed unconditionally but `sshd.service` is only enabled when `xibo.ssh_pubkey=` is present. Without the pubkey preseed, the kiosk has no inbound SSH surface. Lightweight (~1 MB).
+
 ## 0.4.21 (2026-04-11)
 
 **4-layer power management fix + correct GNOME donation popup suppression** ([#69](https://github.com/xibo-players/xiboplayer-kiosk/issues/69)).

--- a/deb/build-deb.sh
+++ b/deb/build-deb.sh
@@ -34,6 +34,7 @@ install -m755 kiosk/xiboplayer-setup.py "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 install -m644 kiosk/xiboplayer-setup.desktop "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 install -m755 kiosk/xibo-activate-kiosk.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 install -m755 kiosk/xibo-deactivate-kiosk.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
+install -m755 kiosk/xibo-set-wifi.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 
 # System config files — the kiosk DEB IS the kiosk definition, so the
 # system-level config that makes a kiosk stay on forever + suppresses the

--- a/kickstart/xiboplayer-kiosk.ks
+++ b/kickstart/xiboplayer-kiosk.ks
@@ -90,6 +90,10 @@ avahi
 nss-mdns
 wireguard-tools
 NetworkManager-wifi
+openssh-server
+
+# Preseed tooling — jq parses xibo.config_url JSON + USB setup.json (#73)
+jq
 
 # Remove unnecessary packages
 -gnome-tour
@@ -158,8 +162,81 @@ alternatives --install /usr/bin/xiboplayer xiboplayer /usr/bin/xiboplayer-chromi
 alternatives --install /usr/bin/xiboplayer xiboplayer /usr/bin/xiboplayer-electron 20
 alternatives --install /usr/bin/xiboplayer xiboplayer /usr/bin/arexibo 10
 
-# Set default player from xibo.profile kernel parameter
-PROFILE=$(sed -n 's/.*xibo\.profile=\([^ ]*\).*/\1/p' /proc/cmdline)
+# ========================================================================
+# Preseed parsing (#68) — extract xibo.* kernel cmdline params and the
+# xibo.config_url= JSON fetch into /etc/xiboplayer-preseed.env.
+# ========================================================================
+# Four-layer precedence (most specific wins):
+#   Layer 0  — baked-in defaults (profile=chromium if nothing given)
+#   Layer 1  — xibo.config_url=https://…/setup.json (curl+jq in %post)
+#   Layer 2  — USB /setup.json (#73 adds xibo-usb-preseed.sh)
+#   Layer 3  — per-field xibo.*= kernel params (this block, overrides above)
+#   Layer 4  — interactive zenity menu (#67, reads preseed.env, prompts gaps)
+#
+# Layer 1 and 3 are implemented here. Layer 2 reuses the same env file via
+# xibo-usb-preseed.sh. Layer 4 reads the env file via a _preseed_get()
+# helper in kiosk/xibo-zenity-lib.sh (#67).
+#
+# Security: the jq allowlist regex rejects shell metacharacters BEFORE
+# writing to preseed.env. The preseed file is NEVER sourced with `.` —
+# values are extracted via grep+cut to avoid the shell parser entirely
+# (defense-in-depth against a future maintainer weakening the regex).
+
+install -d /etc
+
+# --- Layer 1: xibo.config_url= JSON fetch -------------------------------
+CONFIG_URL=$(sed -n 's/.*xibo\.config_url=\([^ ]*\).*/\1/p' /proc/cmdline)
+if [ -n "$CONFIG_URL" ]; then
+    echo "preseed: fetching $CONFIG_URL"
+    # curl is in the anaconda environment; jq was added to %packages.
+    # --fail → non-zero on HTTP error. --max-time 30 → bounded wait.
+    # --silent → no progress meter in install log. Allowlist regex:
+    # alphanumerics, dot, underscore, slash, hyphen, colon, at, plus,
+    # equals, space. Rejects $, backtick, ;, &, |, >, <, \, newline.
+    if curl --silent --fail --max-time 30 "$CONFIG_URL" \
+        | jq -r '
+            to_entries[]
+            | select(.value | type == "string")
+            | select(.value | test("^[A-Za-z0-9._/@:+=\\- ]+$"))
+            | "xibo.\(.key)=\(.value)"
+        ' > /etc/xiboplayer-preseed.env 2>/dev/null; then
+        echo "preseed: fetched $(wc -l < /etc/xiboplayer-preseed.env) key(s) from config_url"
+    else
+        echo "preseed: WARNING — config_url fetch failed or returned invalid JSON, continuing" >&2
+        : > /etc/xiboplayer-preseed.env
+    fi
+else
+    : > /etc/xiboplayer-preseed.env
+fi
+
+# --- Layer 3: per-field xibo.*= kernel params (override Layer 1) --------
+# Walk every token on /proc/cmdline, extract anything matching xibo.KEY=VAL,
+# overwrite the corresponding line in preseed.env. The xibo.config_url key
+# itself is skipped — it's an instruction for Layer 1, not a value to store.
+for tok in $(tr ' ' '\n' < /proc/cmdline | grep -E '^xibo\.[a-z_]+='); do
+    key="${tok%%=*}"
+    val="${tok#*=}"
+    if [ "$key" = "xibo.config_url" ]; then
+        continue
+    fi
+    # Remove any previous entry for this key (from Layer 1), then append.
+    sed -i "/^${key//./\\.}=/d" /etc/xiboplayer-preseed.env 2>/dev/null || true
+    echo "${key}=${val}" >> /etc/xiboplayer-preseed.env
+done
+
+echo "preseed: /etc/xiboplayer-preseed.env now has $(wc -l < /etc/xiboplayer-preseed.env) line(s)"
+
+# --- _preseed_get helper (inline — no sourcing the env file) ------------
+# Extracts a single key's value by exact name. Fails closed (empty string)
+# if the file is missing or the key is absent. Used below + by Item A's
+# xibo-zenity-lib.sh at runtime.
+_preseed_get() {
+    grep "^$1=" /etc/xiboplayer-preseed.env 2>/dev/null | head -1 | cut -d= -f2-
+}
+
+# --- Profile selection (was the whole previous block, still authoritative) --
+# Keeps the old behaviour: default chromium if unset or unrecognised.
+PROFILE=$(_preseed_get "xibo.profile")
 PROFILE="${PROFILE:-chromium}"
 
 case "$PROFILE" in
@@ -181,6 +258,56 @@ cat > /home/xibo/.config/xiboplayer/setup-result.json << SETUPEOF
 SETUPEOF
 chown -R xibo:xibo /home/xibo/.config/xiboplayer
 echo "Default player: $PLAYER ($SERVICE)"
+
+# --- Apply system-level preseed values immediately (we're already root) --
+# Timezone and locale are straightforward system-level calls. Wi-Fi uses
+# the xibo-set-wifi.sh helper installed by the xiboplayer-kiosk RPM at
+# /usr/share/xiboplayer-kiosk/xibo-set-wifi.sh (new in #68). The SSH
+# pubkey (if set) writes the xibo user's authorized_keys and enables
+# sshd.service so MSPs can remote-diagnose via the debug dump (#70).
+
+XIBO_TIMEZONE=$(_preseed_get "xibo.timezone")
+if [ -n "$XIBO_TIMEZONE" ]; then
+    timedatectl set-timezone "$XIBO_TIMEZONE" 2>/dev/null \
+        && echo "preseed: timezone set to $XIBO_TIMEZONE" \
+        || echo "preseed: WARNING — timedatectl set-timezone $XIBO_TIMEZONE failed" >&2
+fi
+
+XIBO_LOCALE=$(_preseed_get "xibo.locale")
+if [ -n "$XIBO_LOCALE" ]; then
+    localectl set-locale "LANG=$XIBO_LOCALE" 2>/dev/null \
+        && echo "preseed: locale set to $XIBO_LOCALE" \
+        || echo "preseed: WARNING — localectl set-locale $XIBO_LOCALE failed" >&2
+fi
+
+XIBO_WIFI_SSID=$(_preseed_get "xibo.wifi_ssid")
+XIBO_WIFI_PSK=$(_preseed_get "xibo.wifi_psk")
+if [ -n "$XIBO_WIFI_SSID" ]; then
+    # Already root in kickstart %post — call the helper directly, no doas.
+    /usr/share/xiboplayer-kiosk/xibo-set-wifi.sh "$XIBO_WIFI_SSID" "$XIBO_WIFI_PSK" \
+        && echo "preseed: wifi connected to $XIBO_WIFI_SSID" \
+        || echo "preseed: WARNING — wifi helper failed for $XIBO_WIFI_SSID" >&2
+fi
+
+# SSH pubkey — allows MSP remote support. The value is URL-encoded (spaces
+# as %20) to survive kernel cmdline quoting. Example:
+#   xibo.ssh_pubkey=ssh-ed25519%20AAAAC3...%20operator@msp
+# We decode the spaces back before writing the key.
+XIBO_SSH_PUBKEY=$(_preseed_get "xibo.ssh_pubkey")
+if [ -n "$XIBO_SSH_PUBKEY" ]; then
+    install -d -m 0700 -o xibo -g xibo /home/xibo/.ssh
+    # Replace %20 with space (the most common case) and trim trailing newline.
+    # Any other percent-encoding the operator used will be preserved as-is
+    # in the authorized_keys line, which is harmless if it matches what the
+    # client sends (it won't match if the operator made a mistake, and the
+    # only symptom is "key not accepted" — fail closed, operator fixes).
+    decoded=$(printf '%s' "$XIBO_SSH_PUBKEY" | sed 's/%20/ /g')
+    echo "$decoded" > /home/xibo/.ssh/authorized_keys
+    chmod 0600 /home/xibo/.ssh/authorized_keys
+    chown xibo:xibo /home/xibo/.ssh/authorized_keys
+    systemctl enable sshd.service 2>/dev/null || true
+    echo "preseed: ssh pubkey installed, sshd enabled"
+fi
 %end
 
 # Configure xibo user and directories
@@ -224,7 +351,11 @@ SystemAccount=false
 EOF
 %end
 
-# Configure opendoas
+# Configure opendoas.
+# MUST match mkosi-extra/etc/doas.conf byte-for-byte. The two copies serve
+# parallel install paths (kickstart-installed targets don't get mkosi-extra/)
+# and drift between them causes bugs like #67's WiFi flow failing with
+# 'permission denied' on kickstart-installed machines (Phase 6-bis finding).
 %post --erroronfail
 cat > /etc/doas.conf << 'EOF'
 permit nopass xibo cmd reboot
@@ -234,6 +365,7 @@ permit nopass xibo cmd localectl
 permit nopass xibo cmd timedatectl
 permit nopass xibo cmd /usr/share/xiboplayer-kiosk/xibo-activate-kiosk.sh
 permit nopass xibo cmd /usr/share/xiboplayer-kiosk/xibo-deactivate-kiosk.sh
+permit nopass xibo cmd /usr/share/xiboplayer-kiosk/xibo-set-wifi.sh
 EOF
 chmod 600 /etc/doas.conf
 %end
@@ -328,29 +460,76 @@ chown -R xibo:xibo /home/xibo
 dnf clean all
 %end
 
-# Auto-detect install disk — find the first non-USB, non-removable disk.
-# Writes disk partitioning commands to /tmp/disk-config for %include.
+# Auto-detect install disk — "best available" heuristic.
+#
+# Preference order (most→least preferred bus class): NVMe > virtio > SATA.
+# Within the first class that yields ANY qualifying disk, pick the LARGEST.
+# Stop at the first class with a match — don't mix NVMe and SATA candidates.
+#
+# Rationale: kiosk hardware typically has a single internal disk that
+# belongs to the fastest available bus class. When a machine has e.g. one
+# NVMe + one SATA spinner, the NVMe should always win. When a machine has
+# two identical NVMes (rare), the larger one wins. When a machine has only
+# SATA, that's what we install on.
+#
+# Skipped: removable devices (USB sticks, SD-card-in-USB-reader,
+# CD-ROMs), disks smaller than 8 GB (too small for a kiosk image).
+#
+# Logs EVERY candidate considered to /tmp/disk-autodetect.log so the
+# anaconda install log shows the full selection trail.
 %pre --erroronfail
 DISK=""
-for dev in /sys/block/nvme* /sys/block/vd* /sys/block/sd*; do
-  [ -e "$dev" ] || continue
-  name=$(basename "$dev")
-  # Skip removable devices (USB sticks, CD-ROMs)
-  [ "$(cat "$dev/removable" 2>/dev/null)" = "1" ] && continue
-  # Skip devices smaller than 8GB (likely USB sticks)
-  size_bytes=$(( $(cat "$dev/size") * 512 ))
-  [ "$size_bytes" -lt 8000000000 ] && continue
-  DISK="$name"
-  break
+DISK_SIZE=0
+LOG=/tmp/disk-autodetect.log
+: > "$LOG"
+echo "xibo disk autodetect: $(date)" >> "$LOG"
+
+# Outer loop: bus preference order (stop at first class with any match)
+for class in nvme vd sd; do
+    for dev in /sys/block/${class}*; do
+        [ -e "$dev" ] || continue
+        name=$(basename "$dev")
+
+        # Skip removable (USB sticks, CD-ROMs, SD cards via usb-storage)
+        if [ "$(cat "$dev/removable" 2>/dev/null)" = "1" ]; then
+            echo "  skip $name: removable=1" >> "$LOG"
+            continue
+        fi
+
+        # Skip small disks (< 8 GB) — almost certainly not the install target
+        size_bytes=$(( $(cat "$dev/size" 2>/dev/null || echo 0) * 512 ))
+        if [ "$size_bytes" -lt 8000000000 ]; then
+            echo "  skip $name: too small (${size_bytes} bytes)" >> "$LOG"
+            continue
+        fi
+
+        rotational=$(cat "$dev/queue/rotational" 2>/dev/null || echo "?")
+        echo "  candidate: $name (${size_bytes} bytes, rotational=$rotational, class=$class)" >> "$LOG"
+
+        # Within this class, track the LARGEST qualifying disk
+        if [ "$size_bytes" -gt "$DISK_SIZE" ]; then
+            DISK="$name"
+            DISK_SIZE="$size_bytes"
+        fi
+    done
+    # If this class yielded a match, skip lower-priority classes
+    if [ -n "$DISK" ]; then
+        echo "  class $class yielded winner $DISK, stopping search" >> "$LOG"
+        break
+    fi
 done
 
 if [ -z "$DISK" ]; then
-  echo "ERROR: No suitable install disk found" >&2
-  # Fallback to sda
-  DISK="sda"
+    echo "ERROR: No suitable install disk found" >&2
+    echo "ERROR: No suitable install disk found" >> "$LOG"
+    # Hard fallback — sda may not exist, but the kickstart must still produce
+    # /tmp/disk-config or anaconda fails the %include at the top of the file.
+    DISK="sda"
+    DISK_SIZE=0
 fi
 
-echo "Selected install disk: $DISK" >&2
+echo "Selected install disk: /dev/$DISK ($DISK_SIZE bytes)" >&2
+echo "WINNER: $DISK ($DISK_SIZE bytes)" >> "$LOG"
 cat > /tmp/disk-config << EOF
 zerombr
 clearpart --all --initlabel --disklabel=gpt --drives=$DISK

--- a/kiosk/xibo-set-wifi.sh
+++ b/kiosk/xibo-set-wifi.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# xibo-set-wifi.sh — NetworkManager keyfile writer for xiboplayer-kiosk.
+#
+# Usage:
+#   xibo-set-wifi.sh <SSID> <password> [key-mgmt]
+#
+# Arguments:
+#   SSID       — network name (exact, used as NM connection id)
+#   password   — pre-shared key (empty string for open networks)
+#   key-mgmt   — wpa-psk (default) | none (open network)
+#
+# Writes /etc/NetworkManager/system-connections/<safe-name>.nmconnection
+# at mode 0600 root:root, then calls `nmcli connection reload` and
+# `nmcli connection up`. The password is NEVER passed on an nmcli CLI
+# argument, so it does not appear in /proc/<pid>/cmdline — closing the
+# brief exposure window that `nmcli dev wifi connect … password …` has.
+#
+# Invoked via doas from the xibo user (see /etc/doas.conf), or directly
+# as root from kickstart %post (no doas needed — already root there).
+# Either way, the script must be owned root:root with mode 0755 and
+# doas.conf must grant the xibo user the exact path.
+#
+# SECURITY: input validation rejects control characters (newline/tab/
+# null) and NM INI section headers inside the SSID or PSK. Without
+# this, a PSK containing e.g.
+#   "password\n[wifi-security]\nkey-mgmt=none"
+# could inject a fake INI section into the generated keyfile. Not an
+# RCE (bash parameter expansion is single-pass, heredoc values are
+# not re-parsed) but a format-injection risk. Fail closed with exit 2.
+#
+# The _validate_nm_string function below is the authoritative source
+# of this validation. The same function is copied VERBATIM into
+# kickstart/xibo-wifi-tui.sh (invoked by the pre-anaconda WiFi picker
+# in issue #72) so both paths produce byte-identical NM keyfiles for
+# the same input. bats test at tests/unit/set-wifi.bats (issue #74)
+# enforces this identity.
+
+set -e
+
+SSID="$1"
+PSK="$2"
+KEYMGMT="${3:-wpa-psk}"
+
+[ -z "$SSID" ] && { echo "xibo-set-wifi.sh: SSID required" >&2; exit 1; }
+
+# --- input validation (authoritative source — see header) ---------------
+_validate_nm_string() {
+    local label="$1" value="$2"
+    if printf '%s' "$value" | grep -qE $'[\x00-\x1f]'; then
+        echo "xibo-set-wifi.sh: $label contains control characters (newline/tab/null) — rejected" >&2
+        exit 2
+    fi
+    if printf '%s' "$value" | grep -qE '^\[|\[(connection|wifi|wifi-security|ipv4|ipv6)\]'; then
+        echo "xibo-set-wifi.sh: $label contains an NM INI section header — rejected" >&2
+        exit 2
+    fi
+}
+_validate_nm_string "SSID" "$SSID"
+[ -n "$PSK" ] && _validate_nm_string "PSK" "$PSK"
+
+# --- filename sanitisation -------------------------------------------------
+# NM connection `id=` accepts the raw SSID verbatim, but the keyfile
+# filename must be safe (no slashes, quotes, etc.). Replace any non-
+# alphanumeric + `._-` character with `_`. The `/` character is NOT in
+# the allowed set so path-traversal attempts like `../../etc/passwd`
+# become `______etc_passwd` — the resulting file lives safely inside
+# /etc/NetworkManager/system-connections/ regardless of SSID content.
+SAFE_NAME=$(printf '%s' "$SSID" | tr -c '[:alnum:]._-' '_')
+KEYFILE="/etc/NetworkManager/system-connections/${SAFE_NAME}.nmconnection"
+UUID=$(cat /proc/sys/kernel/random/uuid)
+
+# --- delete any previous connection with the same id (idempotent re-run) --
+# NM matches by connection id, not by filename, so we delete by $SSID.
+if nmcli -t -f NAME con show 2>/dev/null | grep -Fxq "$SSID"; then
+    nmcli con delete "$SSID" 2>/dev/null || true
+fi
+
+# --- write the keyfile ----------------------------------------------------
+# umask ensures the file is created with no group/other perms; chmod
+# below is belt-and-braces for the case where umask was lax.
+umask 077
+mkdir -p /etc/NetworkManager/system-connections
+
+if [ "$KEYMGMT" = "none" ] || [ -z "$PSK" ]; then
+    # Open network — no [wifi-security] section.
+    cat > "$KEYFILE" << EOF
+[connection]
+id=$SSID
+uuid=$UUID
+type=wifi
+autoconnect=true
+
+[wifi]
+mode=infrastructure
+ssid=$SSID
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=ignore
+EOF
+else
+    cat > "$KEYFILE" << EOF
+[connection]
+id=$SSID
+uuid=$UUID
+type=wifi
+autoconnect=true
+
+[wifi]
+mode=infrastructure
+ssid=$SSID
+
+[wifi-security]
+key-mgmt=$KEYMGMT
+psk=$PSK
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=ignore
+EOF
+fi
+
+chmod 600 "$KEYFILE"
+chown root:root "$KEYFILE"
+
+# --- activate -------------------------------------------------------------
+# nmcli matches by connection id (the SSID), not by filename. Use the
+# raw SSID here so SSIDs with special characters that got sanitised in
+# the filename still work. `|| true` tolerates transient NM states
+# during early boot.
+nmcli connection reload 2>/dev/null || true
+nmcli connection up "$SSID" 2>/dev/null || true
+
+# --- persist SSID (never the PSK) to the preseed env file for visibility
+# on Ctrl+R full-setup re-runs (issue #67). The preseed env file is
+# written by kickstart %post at install time and may be updated here
+# when the zenity menu writes a new connection at runtime. PSK is never
+# recorded — the NM keyfile itself is the authoritative PSK store.
+if [ -f /etc/xiboplayer-preseed.env ] || [ -w /etc ]; then
+    sed -i '/^xibo\.wifi_ssid=/d' /etc/xiboplayer-preseed.env 2>/dev/null || true
+    echo "xibo.wifi_ssid=$SSID" >> /etc/xiboplayer-preseed.env 2>/dev/null || true
+fi
+
+echo "xibo-set-wifi.sh: wrote $KEYFILE (id=$SSID)"

--- a/mkosi-extra/etc/doas.conf
+++ b/mkosi-extra/etc/doas.conf
@@ -6,3 +6,4 @@ permit nopass xibo cmd timedatectl
 permit nopass xibo cmd systemctl args restart NetworkManager
 permit nopass xibo cmd /usr/share/xiboplayer-kiosk/xibo-activate-kiosk.sh
 permit nopass xibo cmd /usr/share/xiboplayer-kiosk/xibo-deactivate-kiosk.sh
+permit nopass xibo cmd /usr/share/xiboplayer-kiosk/xibo-set-wifi.sh

--- a/rpm/xiboplayer-kiosk.spec
+++ b/rpm/xiboplayer-kiosk.spec
@@ -1,5 +1,5 @@
 Name:           xiboplayer-kiosk
-Version:        0.4.21
+Version:        0.4.22
 Release:        1%{?dist}
 Summary:        Kiosk session scripts for Xibo digital signage players
 
@@ -63,6 +63,10 @@ install -Dm755 kiosk/xiboplayer-setup.py %{buildroot}%{_datadir}/xiboplayer-kios
 install -Dm644 kiosk/xiboplayer-setup.desktop %{buildroot}%{_datadir}/xiboplayer-kiosk/xiboplayer-setup.desktop
 install -Dm755 kiosk/xibo-activate-kiosk.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-activate-kiosk.sh
 install -Dm755 kiosk/xibo-deactivate-kiosk.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-deactivate-kiosk.sh
+# Issue #68 — NM keyfile writer (called by doas from the xibo user or directly
+# by root from kickstart %post). Never passes the PSK on the nmcli CLI,
+# closing the /proc/<pid>/cmdline leak window.
+install -Dm755 kiosk/xibo-set-wifi.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-set-wifi.sh
 
 # System config files — the kiosk RPM IS the kiosk definition, so the
 # system-level config that makes a kiosk stay on forever + suppresses the
@@ -97,6 +101,7 @@ install -m755 kiosk/gnome-kiosk-script.sh %{buildroot}%{_sysconfdir}/skel/.local
 %{_datadir}/xiboplayer-kiosk/xiboplayer-setup.desktop
 %{_datadir}/xiboplayer-kiosk/xibo-activate-kiosk.sh
 %{_datadir}/xiboplayer-kiosk/xibo-deactivate-kiosk.sh
+%{_datadir}/xiboplayer-kiosk/xibo-set-wifi.sh
 %{_sysconfdir}/keyd/xibo.conf
 %{_sysconfdir}/yum.repos.d/copr-keyd.repo
 %{_sysconfdir}/skel/.local/bin/gnome-kiosk-script
@@ -119,6 +124,34 @@ install -m755 kiosk/gnome-kiosk-script.sh %{buildroot}%{_sysconfdir}/skel/.local
 /usr/bin/dconf update &>/dev/null || :
 
 %changelog
+* Sat Apr 11 2026 Pau Aliagas <linuxnow@gmail.com> - 0.4.22-1
+- iPXE / kernel preseed infrastructure + best-available-disk autodetect
+  (#68). Kickstart %post now parses every xibo.* kernel param, fetches
+  xibo.config_url= JSON via curl+jq with an inline allowlist regex that
+  rejects shell metacharacters, writes everything to
+  /etc/xiboplayer-preseed.env, and applies system-level values
+  (timedatectl, localectl, wifi via xibo-set-wifi.sh, ssh pubkey with
+  sshd enablement).
+- Supported xibo.* params: profile, config_url, cms_url, cms_key,
+  display_name, timezone, locale, wifi_ssid, wifi_psk, ssh_pubkey.
+- 4-layer precedence: baked defaults -> xibo.config_url= JSON ->
+  USB /setup.json (reserved for #73) -> per-field xibo.*= kernel params
+  -> zenity menu prompts (reserved for #67). Per-field params override
+  the URL JSON.
+- New kiosk/xibo-set-wifi.sh — NetworkManager keyfile writer that avoids
+  the /proc/<pid>/cmdline PSK leak of 'nmcli dev wifi connect … password
+  …'. Input validation rejects control characters and NM INI section
+  headers in the SSID/PSK. Permitted via doas for the xibo user in both
+  mkosi-extra/etc/doas.conf and the kickstart heredoc.
+- Best-available-disk %pre autodetect — replaces the previous 'first
+  non-removable >8GB' walk with a 'largest in best-preferred bus class'
+  heuristic. Preference order NVMe > virtio > SATA; stops at first class
+  with any match; within the winning class, picks the largest qualifying
+  disk; logs every candidate to /tmp/disk-autodetect.log for debug.
+- Added 'jq' and 'openssh-server' to kickstart %packages. jq is needed
+  by the config_url fetch pipeline and by #73's USB setup.json scanner.
+  sshd is enabled only when xibo.ssh_pubkey= is set.
+
 * Sat Apr 11 2026 Pau Aliagas <linuxnow@gmail.com> - 0.4.21-1
 - 4-layer power management fix + correct GNOME donation popup suppression
   (#69). Fixes screen blanking observed on 0.4.19 (Singularity 6 #370) and


### PR DESCRIPTION
## Summary

Closes #68. Bumps `0.4.21` → `0.4.22`.

Foundation layer for unattended and partially-attended kiosk deployment. Establishes `/etc/xiboplayer-preseed.env` as the single source of truth for preseeded values, consumed by the zenity first-boot menu (#67), pre-anaconda whiptail TUI (#72), and USB auto-detect scanner (#73) once those land.

## 4-layer precedence (most specific wins)

```
Layer 0  baked-in defaults (profile=chromium if nothing given)
Layer 1  xibo.config_url=https://…/setup.json (curl+jq in %post)
Layer 2  USB /setup.json (reserved for #73)
Layer 3  per-field xibo.*= kernel params (this PR, overrides above)
Layer 4  interactive zenity menu (reserved for #67)
```

## Supported \`xibo.*\` kernel params

\`profile\`, \`config_url\`, \`cms_url\`, \`cms_key\`, \`display_name\`, \`timezone\`, \`locale\`, \`wifi_ssid\`, \`wifi_psk\`, \`ssh_pubkey\`.

## New file: \`kiosk/xibo-set-wifi.sh\`

NetworkManager keyfile writer. Writes \`/etc/NetworkManager/system-connections/<SSID>.nmconnection\` at \`0600 root:root\` instead of calling \`nmcli dev wifi connect … password …\`, closing the brief \`/proc/<pid>/cmdline\` PSK leak.

- **Input validation** rejects control characters and NM INI section headers in SSID/PSK — prevents fake \`[wifi-security]\` section injection via crafted PSK values.
- **SSID filename sanitisation** via \`tr -c '[:alnum:]._-' '_'\` — path traversal attempts become harmless underscore runs.
- The \`_validate_nm_string\` function is the **authoritative source**; the same function will be copied verbatim into \`kickstart/xibo-wifi-tui.sh\` when #72 lands. bats test at \`tests/unit/set-wifi.bats\` (#74) will enforce byte-identical keyfile output between the two copies.
- Shipped by RPM (\`%install\` + \`%files\`) and DEB (\`install\` line in \`build-deb.sh\`).
- Permitted via doas for the \`xibo\` user in **both** \`mkosi-extra/etc/doas.conf\` **and** the kickstart doas heredoc — matching the Phase 6-bis review finding that both copies must be kept in sync.

## Kickstart \`%post\` additions

- Parses every \`xibo.*=\` token on \`/proc/cmdline\`, skipping \`xibo.config_url\` (that's the Layer 1 fetch instruction, not a value to store).
- If \`xibo.config_url=\` present: \`curl --silent --fail --max-time 30\` + \`jq\` with an **inline allowlist regex** (\`^[A-Za-z0-9._/@:+=\\- ]+\$\`) that rejects shell metacharacters (\`\$\`, backtick, \`;\`, \`&\`, \`|\`, \`>\`, \`<\`, \`\\\`, newline) **before** values are written to \`preseed.env\`. Keeps the file safe even though it's never \`source\`d.
- \`_preseed_get()\` helper extracts values via \`grep | cut\` — the preseed file is **never** sourced with \`.\`, closing the shell-parser attack surface (defense in depth against a future maintainer weakening the regex).
- Applies system-level values immediately: \`timedatectl set-timezone\`, \`localectl set-locale LANG=…\`, \`xibo-set-wifi.sh <SSID> <PSK>\` (root, no doas needed in %post), and the \`xibo.ssh_pubkey=\` pubkey → \`/home/xibo/.ssh/authorized_keys\` + \`systemctl enable sshd.service\` dance.
- \`xibo.ssh_pubkey=\` is **URL-encoded** on the kernel cmdline (\`%20\` for space) to survive quoting. Example: \`xibo.ssh_pubkey=ssh-ed25519%20AAAAC3…%20operator@msp\`. Decoded back to spaces before writing \`authorized_keys\`.

## \`%pre\` best-available-disk autodetect rewrite

Replaces the previous "first non-removable ≥8 GB" walk with a ranked "largest in best-preferred bus class" heuristic:

1. Preference order: **NVMe > virtio > SATA**. Stops at the first class with any match — doesn't mix candidates across classes.
2. Within the winning class, picks the **largest** qualifying disk.
3. Removable devices skipped via \`/sys/block/*/removable == 1\`.
4. Disks < 8 GB skipped.
5. **Logs every candidate** (name + size + rotational + class) to \`/tmp/disk-autodetect.log\` for debug. Previous version only logged the winner.
6. Fallback to \`DISK=sda\` if nothing qualifies — anaconda still gets a valid \`/tmp/disk-config\` to \`%include\`.

## Packages added to kickstart \`%packages\`

- \`jq\` (~1 MB, no weak deps) — required by config_url fetch pipeline and #73's USB setup.json scanner.
- \`openssh-server\` (~1 MB) — installed unconditionally but \`sshd.service\` is only enabled when \`xibo.ssh_pubkey=\` is present.

## Security notes

- \`xibo.config_url=\` values should use **path-based tokens** (e.g. \`https://ops.example.com/k/a8f2c9d1b4e7.json\`) rather than inline \`user:pass@host\` credentials. The full URL is captured in \`/proc/cmdline\` AND in the anaconda install logs. Path-based secrets are rotatable without touching the installed machine; Basic Auth credentials in the URL are not.
- The jq allowlist regex is a defence-in-depth layer: even if a future maintainer accidentally introduces \`source /etc/xiboplayer-preseed.env\` elsewhere, the values are already free of shell metacharacters thanks to this filter.

## Test plan

- [ ] \`rpmbuild -ba rpm/xiboplayer-kiosk.spec\` succeeds with the new version and %install/%files entries
- [ ] \`./deb/build-deb.sh 0.4.22\` succeeds
- [ ] \`xibo-set-wifi.sh TestSSID TestPSK\` writes the expected keyfile at \`/etc/NetworkManager/system-connections/TestSSID.nmconnection\` with mode 0600
- [ ] \`xibo-set-wifi.sh \"foo\\nbar\" \"pw\"\` (newline in SSID) exits non-zero with the \"control characters\" error
- [ ] \`xibo-set-wifi.sh foo \"pw\\n[wifi-security]\\nkey-mgmt=none\"\` (INI injection in PSK) exits non-zero with the \"INI section header\" error
- [ ] Manual test: boot Everything ISO with \`xibo.cms_url=https://cms.test xibo.cms_key=ABC xibo.timezone=Europe/Madrid\` — all three fields appear in \`/etc/xiboplayer-preseed.env\` after install, timezone is set
- [ ] Manual test: boot with \`xibo.config_url=https://host/setup.json\` pointing at a known-good JSON — values land in preseed.env, no shell injection if JSON contains metacharacters
- [ ] Manual test: best-available-disk picks NVMe over SATA on a multi-disk VM, picks the larger NVMe when two are present
- [ ] Manual test: \`xibo.ssh_pubkey=ssh-ed25519%20…%20test\` (URL-encoded) results in working \`authorized_keys\` after install and sshd is enabled

Closes #68.