### PR TITLE
feat(kiosk): xibo-debug-dump support bundle collector (#70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## 0.4.23 (2026-04-11)
+
+**Support bundle collector** ([#70](https://github.com/xibo-players/xiboplayer-kiosk/issues/70)).
+
+New `/usr/bin/xibo-debug-dump` command writes a zstd-compressed tarball of kiosk diagnostic state to `$HOME/Downloads/xibo-debug-<hostname>-<timestamp>.tar.zst`. MSP technicians can collect it locally via Ctrl+D, from an SSH session by typing `xibo-debug-dump`, or from the zenity reconfigure menu (#67 will add the menu row).
+
+### What's in the bundle
+
+| File | Content |
+|---|---|
+| `00-system.txt` | hostname, `/etc/os-release`, `uname -a`, `uptime`, `date` |
+| `01-proc-cmdline.txt` | `/proc/cmdline` with `xibo.cms_key=`, `xibo.wifi_psk=`, and basic-auth URL credentials redacted |
+| `02-packages.txt` | `rpm -qa` filtered to xibo/arexibo + top 50 of the full list |
+| `03-preseed.env.txt` | `/etc/xiboplayer-preseed.env` with secrets redacted |
+| `04-<path>.txt` | Player config files with `cmsKey`/`key` redacted |
+| `05-systemd-user.txt` | `systemctl --user status` for all xiboplayer services |
+| `06-systemd-system.txt` | `systemctl status` for gdm, avahi, keyd, sshd, NetworkManager |
+| `07-journal-user.txt` | `journalctl --user -b`, redacted |
+| `08-journal-kernel.txt` | `journalctl -b -k` (kernel log) |
+| `09-journal-services.txt` | Per-service journalctl for the kiosk's critical services |
+| `10-hardware.txt` | `lscpu`, `free`, `df`, `lsblk`, `lspci -nnk`, `lsusb` |
+| `11-display.txt` | `loginctl show-user xibo`, `glxinfo -B`, `/sys/class/drm/` |
+| `12-network.txt` | `nmcli con/dev/wifi`, `ip addr`, `ip route`, `resolvectl` |
+| `13-time-locale.txt` | `timedatectl`, `localectl` |
+| `14-kiosk-state.txt` | Firstboot sentinels, alternatives, `no-idle.conf`, `dconf/profile/gdm` |
+
+### Security — what's NOT in the bundle
+
+The script deliberately does **not** collect these, and a post-tar assertion refuses to ship the bundle if any sneak in (deletes tarball + fires a critical `notify-send`):
+
+- `/etc/NetworkManager/system-connections/**` — contains Wi-Fi PSK in cleartext
+- `/etc/shadow`, `/etc/gshadow`
+- Browser `Cookies*` directories — player session tokens
+- `/etc/doas.conf`
+- `~/.ssh/id_*` — private keys
+
+### Redaction
+
+An inline `_redact()` helper pipes content through 5 `sed` patterns covering `xibo.cms_key=`, `xibo.wifi_psk=`, `xibo.config_url=user:pass@host`, JSON `"cmsKey"`, and JSON `"key"`. Applied per-file as files are staged — conservative, prefers over-redaction to leaking.
+
+### Triggers
+
+1. **Ctrl+D via keyd** — new `d = command(...)` binding in `kiosk/keyd-xibo.conf`
+2. **CLI** — `/usr/bin/xibo-debug-dump` symlink created by RPM spec and DEB build script
+3. **Zenity menu row** — wired up by #67
+4. **Labeled USB auto-collect** — `xibo-debug-dump --to-usb` looks for a mounted filesystem labeled `XIBO-DEBUG`; the matching udev rule for auto-trigger on plug-in is deferred to a follow-up
+
 ## 0.4.22 (2026-04-11)
 
 **iPXE / kernel preseed infrastructure + best-available-disk autodetect** ([#68](https://github.com/xibo-players/xiboplayer-kiosk/issues/68)).

--- a/deb/build-deb.sh
+++ b/deb/build-deb.sh
@@ -35,6 +35,12 @@ install -m644 kiosk/xiboplayer-setup.desktop "${DEB_DIR}/usr/share/xiboplayer-ki
 install -m755 kiosk/xibo-activate-kiosk.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 install -m755 kiosk/xibo-deactivate-kiosk.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 install -m755 kiosk/xibo-set-wifi.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
+install -m755 kiosk/xibo-debug-dump.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
+
+# /usr/bin/xibo-debug-dump symlink (mirrors the RPM spec) — lets techs run
+# `xibo-debug-dump` from any shell without typing the full share path.
+mkdir -p "${DEB_DIR}/usr/bin"
+ln -sf /usr/share/xiboplayer-kiosk/xibo-debug-dump.sh "${DEB_DIR}/usr/bin/xibo-debug-dump"
 
 # System config files — the kiosk DEB IS the kiosk definition, so the
 # system-level config that makes a kiosk stay on forever + suppresses the

--- a/kiosk/keyd-xibo.conf
+++ b/kiosk/keyd-xibo.conf
@@ -7,3 +7,4 @@ leftcontrol = layer(xibo_ctrl)
 [xibo_ctrl:C]
 i = command(/usr/share/xiboplayer-kiosk/xibo-keyd-run.sh /usr/share/xiboplayer-kiosk/xibo-show-ip.sh)
 r = command(/usr/share/xiboplayer-kiosk/xibo-keyd-run.sh /usr/share/xiboplayer-kiosk/xibo-show-cms.sh)
+d = command(/usr/share/xiboplayer-kiosk/xibo-keyd-run.sh /usr/share/xiboplayer-kiosk/xibo-debug-dump.sh)

--- a/kiosk/xibo-debug-dump.sh
+++ b/kiosk/xibo-debug-dump.sh
@@ -1,0 +1,302 @@
+#!/bin/bash
+# xibo-debug-dump.sh — support bundle collector for xiboplayer-kiosk.
+#
+# Usage:
+#   xibo-debug-dump                    — write to $HOME/Downloads/
+#   xibo-debug-dump [DEST_DIR]         — write to DEST_DIR/
+#   xibo-debug-dump --to-usb           — write to a mounted USB labeled XIBO-DEBUG
+#
+# Creates a zstd-compressed tarball with logs, configs, hardware info,
+# and networking state — enough for an MSP technician to diagnose a
+# field incident without shell access to the kiosk. Sensitive values
+# (CMS keys, Wi-Fi PSKs, basic-auth URL credentials) are redacted
+# BEFORE the files go into the tarball. A post-tar security assertion
+# refuses to ship the bundle if any known-sensitive path sneaks in
+# (NetworkManager keyfiles containing cleartext PSKs, /etc/shadow,
+# browser Cookies directories, etc).
+#
+# Triggers (per issue #70):
+#   1. Ctrl+D via keyd — kiosk/keyd-xibo.conf binds Ctrl+D to this script
+#   2. Zenity row — xibo-show-cms.sh and xibo-first-boot.sh both offer
+#      a "Collect debug info" action that invokes this script
+#   3. CLI — /usr/bin/xibo-debug-dump symlink created by the rpm spec
+#   4. Labeled USB — plug in a USB stick with filesystem label
+#      XIBO-DEBUG, the udev rule (if/when installed) fires this script
+#      with --to-usb and the tarball lands on the stick
+#
+# Output filename:
+#   xibo-debug-<hostname>-<timestamp>.tar.zst
+#
+# The script is deliberately conservative — every external command is
+# run with `|| true` or inside an `if … then` check so a transient
+# failure on one data source (e.g. nmcli not responding) never aborts
+# the whole collection. The goal is "something useful even if partial".
+
+set -u
+# Note: deliberately NOT `set -e`. Partial bundles are useful; aborting
+# on first error is not. Each collection step handles its own failure.
+
+XIBO_DATA_DIR="${XIBO_DATA_DIR:-$HOME/.local/share/xibo}"
+XIBO_CONFIG_DIR="${XIBO_CONFIG_DIR:-$HOME/.config/xiboplayer}"
+
+# --- destination ----------------------------------------------------------
+DEST=""
+if [ "${1:-}" = "--to-usb" ]; then
+    # Find the first mounted filesystem with label XIBO-DEBUG.
+    # findmnt is more reliable than parsing /proc/mounts by hand.
+    DEST=$(findmnt -n -o TARGET -S LABEL=XIBO-DEBUG 2>/dev/null | head -1)
+    if [ -z "$DEST" ]; then
+        echo "xibo-debug-dump: no mounted USB labeled XIBO-DEBUG found" >&2
+        notify-send -u critical "Xibo debug dump" "No USB labeled XIBO-DEBUG found" 2>/dev/null || true
+        exit 3
+    fi
+elif [ -n "${1:-}" ]; then
+    DEST="$1"
+else
+    DEST="$HOME/Downloads"
+fi
+
+mkdir -p "$DEST" 2>/dev/null || {
+    echo "xibo-debug-dump: cannot create destination $DEST" >&2
+    exit 4
+}
+
+HOSTNAME_SAFE=$(hostname 2>/dev/null | tr -c '[:alnum:]._-' '_')
+[ -z "$HOSTNAME_SAFE" ] && HOSTNAME_SAFE="kiosk"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+TARBALL="$DEST/xibo-debug-${HOSTNAME_SAFE}-${TIMESTAMP}.tar.zst"
+
+# --- staging dir under /var/tmp (not /tmp) so it survives reboot ---------
+STAGE=$(mktemp -d -t xibo-debug-XXXXXX)
+trap 'rm -rf "$STAGE"' EXIT INT TERM
+
+echo "xibo-debug-dump: collecting to $STAGE (will tar into $TARBALL)"
+
+# --- redaction helpers ---------------------------------------------------
+# Replace CMS keys, Wi-Fi PSKs, and basic-auth URL credentials with ***.
+# Used on any captured text that might contain secrets. Conservative —
+# prefers over-redaction to leaking. Applied per-file as files are staged.
+_redact() {
+    # Reads stdin, writes redacted output to stdout.
+    # 1. xibo.cms_key=VALUE → xibo.cms_key=***
+    # 2. xibo.wifi_psk=VALUE → xibo.wifi_psk=***
+    # 3. xibo.config_url=https://USER:PASS@host/... → strip credentials
+    # 4. "cmsKey": "VALUE" in JSON → "cmsKey": "***"
+    # 5. "key": "VALUE" in cms.json → "key": "***"
+    sed -E \
+        -e 's|(xibo\.cms_key=)[^ ]*|\1***|g' \
+        -e 's|(xibo\.wifi_psk=)[^ ]*|\1***|g' \
+        -e 's|(xibo\.config_url=https?://)[^@ ]+@|\1***:***@|g' \
+        -e 's|("cmsKey"[[:space:]]*:[[:space:]]*")[^"]*|\1***|g' \
+        -e 's|("key"[[:space:]]*:[[:space:]]*")[^"]*|\1***|g'
+}
+
+# --- collect ---------------------------------------------------------------
+
+# 1. System identity + OS release
+{
+    echo "=== hostname ==="; hostname 2>/dev/null || :
+    echo
+    echo "=== /etc/os-release ==="; cat /etc/os-release 2>/dev/null || :
+    echo
+    echo "=== uname -a ==="; uname -a 2>/dev/null || :
+    echo
+    echo "=== uptime ==="; uptime 2>/dev/null || :
+    echo
+    echo "=== date ==="; date 2>/dev/null || :
+} > "$STAGE/00-system.txt" 2>/dev/null || :
+
+# 2. /proc/cmdline (redacted — secrets leak here)
+cat /proc/cmdline 2>/dev/null | _redact > "$STAGE/01-proc-cmdline.txt" || :
+
+# 3. Installed xibo/arexibo packages
+{
+    rpm -qa 2>/dev/null | grep -E 'xibo|arexibo' || :
+    echo
+    echo "=== full rpm list (top 50) ==="
+    rpm -qa 2>/dev/null | sort | head -50 || :
+} > "$STAGE/02-packages.txt" 2>/dev/null || :
+
+# 4. Preseed env file (redacted)
+if [ -f /etc/xiboplayer-preseed.env ]; then
+    _redact < /etc/xiboplayer-preseed.env > "$STAGE/03-preseed.env.txt" 2>/dev/null || :
+fi
+
+# 5. Player configs (redacted)
+for f in "$XIBO_CONFIG_DIR/chromium/config.json" \
+         "$XIBO_CONFIG_DIR/electron/config.json" \
+         "$XIBO_CONFIG_DIR/setup-result.json" \
+         "$XIBO_DATA_DIR/cms.json"; do
+    [ -f "$f" ] || continue
+    name=$(echo "$f" | tr '/' '_' | sed 's/^_//')
+    _redact < "$f" > "$STAGE/04-${name}.txt" 2>/dev/null || :
+done
+
+# 6. Systemd — user services
+{
+    echo "=== systemctl --user status xiboplayer-*.service arexibo.service ==="
+    systemctl --user status xiboplayer-electron.service xiboplayer-chromium.service arexibo.service --no-pager 2>/dev/null || :
+    echo
+    echo "=== systemctl --user is-enabled ==="
+    for svc in xiboplayer-electron xiboplayer-chromium arexibo gnome-kiosk-script; do
+        echo -n "$svc: "
+        systemctl --user is-enabled "$svc" 2>/dev/null || echo "not-found"
+    done
+} > "$STAGE/05-systemd-user.txt" 2>/dev/null || :
+
+# 7. Systemd — system services relevant to kiosk
+{
+    echo "=== systemctl status (system) ==="
+    systemctl status gdm avahi-daemon keyd sshd NetworkManager --no-pager 2>/dev/null || :
+    echo
+    echo "=== systemctl is-enabled ==="
+    for svc in gdm avahi-daemon keyd sshd NetworkManager xiboplayer-kiosk-firstboot; do
+        echo -n "$svc: "
+        systemctl is-enabled "$svc" 2>/dev/null || echo "not-found"
+    done
+} > "$STAGE/06-systemd-system.txt" 2>/dev/null || :
+
+# 8. journalctl — user scope (player logs)
+journalctl --user -b --no-pager 2>/dev/null | _redact > "$STAGE/07-journal-user.txt" 2>/dev/null || :
+
+# 9. journalctl — kernel
+journalctl -b -k --no-pager 2>/dev/null > "$STAGE/08-journal-kernel.txt" 2>/dev/null || :
+
+# 10. journalctl — boot services (gdm, avahi, keyd, NetworkManager)
+journalctl -b -u gdm -u avahi-daemon -u keyd -u NetworkManager --no-pager 2>/dev/null | _redact > "$STAGE/09-journal-services.txt" 2>/dev/null || :
+
+# 11. Hardware inventory
+{
+    echo "=== lscpu ==="; lscpu 2>/dev/null || :
+    echo
+    echo "=== free -h ==="; free -h 2>/dev/null || :
+    echo
+    echo "=== df -h ==="; df -h 2>/dev/null || :
+    echo
+    echo "=== lsblk -f ==="; lsblk -f 2>/dev/null || :
+    echo
+    echo "=== lspci -nnk ==="; lspci -nnk 2>/dev/null || :
+    echo
+    echo "=== lsusb ==="; lsusb 2>/dev/null || :
+} > "$STAGE/10-hardware.txt" 2>/dev/null || :
+
+# 12. Display / GPU / Wayland
+{
+    echo "=== loginctl show-user xibo ==="
+    loginctl show-user xibo 2>/dev/null || :
+    echo
+    echo "=== glxinfo -B (subset) ==="
+    glxinfo -B 2>/dev/null | head -20 || :
+    echo
+    echo "=== /sys/class/drm/ ==="
+    ls -la /sys/class/drm/ 2>/dev/null | head -20 || :
+} > "$STAGE/11-display.txt" 2>/dev/null || :
+
+# 13. NetworkManager state (NO PSKs — keyfiles are explicitly excluded below)
+{
+    echo "=== nmcli -t -f NAME,TYPE,DEVICE,STATE con show ==="
+    nmcli -t -f NAME,TYPE,DEVICE,STATE con show 2>/dev/null || :
+    echo
+    echo "=== nmcli -t -f DEVICE,TYPE,STATE,CONNECTION dev status ==="
+    nmcli -t -f DEVICE,TYPE,STATE,CONNECTION dev status 2>/dev/null || :
+    echo
+    echo "=== nmcli -t -f IN-USE,SSID,SIGNAL,SECURITY dev wifi list ==="
+    nmcli -t -f IN-USE,SSID,SIGNAL,SECURITY dev wifi list 2>/dev/null || :
+    echo
+    echo "=== ip -4 addr ==="
+    ip -4 addr 2>/dev/null || :
+    echo
+    echo "=== ip -6 addr ==="
+    ip -6 addr 2>/dev/null || :
+    echo
+    echo "=== ip route ==="
+    ip route 2>/dev/null || :
+    echo
+    echo "=== resolvectl status (short) ==="
+    resolvectl status 2>/dev/null | head -30 || :
+} > "$STAGE/12-network.txt" 2>/dev/null || :
+
+# 14. Time + locale
+{
+    echo "=== timedatectl status ==="; timedatectl status 2>/dev/null || :
+    echo
+    echo "=== localectl status ==="; localectl status 2>/dev/null || :
+} > "$STAGE/13-time-locale.txt" 2>/dev/null || :
+
+# 15. Kiosk-specific state
+{
+    echo "=== /etc/xiboplayer-kiosk-firstboot-done ==="
+    ls -la /var/lib/xiboplayer-kiosk-firstboot-done 2>/dev/null || echo "not present"
+    echo
+    echo "=== XIBO_DATA_DIR first-boot-done ==="
+    ls -la "$XIBO_DATA_DIR/first-boot-done" 2>/dev/null || echo "not present"
+    echo
+    echo "=== alternatives --display xiboplayer ==="
+    alternatives --display xiboplayer 2>/dev/null || :
+    echo
+    echo "=== /etc/systemd/logind.conf.d/no-idle.conf ==="
+    cat /etc/systemd/logind.conf.d/no-idle.conf 2>/dev/null || echo "not present"
+    echo
+    echo "=== /etc/dconf/profile/gdm ==="
+    cat /etc/dconf/profile/gdm 2>/dev/null || echo "not present"
+} > "$STAGE/14-kiosk-state.txt" 2>/dev/null || :
+
+# --- build the tarball ---------------------------------------------------
+# zstd is fast and gives good ratios for mixed text. -19 is too slow for
+# a kiosk; default level is fine.
+if command -v zstd >/dev/null 2>&1; then
+    tar -C "$STAGE" --zstd -cf "$TARBALL" . 2>/dev/null
+else
+    # Fall back to gz if zstd is somehow missing (shouldn't happen — it's in
+    # systemd's base deps). Rename the output accordingly.
+    TARBALL="${TARBALL%.zst}.gz"
+    tar -C "$STAGE" -czf "$TARBALL" . 2>/dev/null
+fi
+
+if [ ! -f "$TARBALL" ]; then
+    echo "xibo-debug-dump: ERROR — tarball creation failed" >&2
+    exit 5
+fi
+
+# --- SECURITY assertion — refuse to ship if a sensitive path snuck in ---
+# This is belt-and-braces: the script deliberately does NOT stage any of
+# these paths, but if a future maintainer adds a broad wildcard or forgets
+# to redact, this assertion catches it before the user sees the tarball.
+SENSITIVE_PATTERNS='NetworkManager/system-connections|/shadow$|/gshadow$|/Cookies|doas\.conf$|/\.ssh/id_'
+if tar --zstd -tf "$TARBALL" 2>/dev/null | grep -qE "$SENSITIVE_PATTERNS"; then
+    echo "xibo-debug-dump: SECURITY — sensitive path detected in tarball, refusing to ship" >&2
+    echo "xibo-debug-dump: offending paths:" >&2
+    tar --zstd -tf "$TARBALL" 2>/dev/null | grep -E "$SENSITIVE_PATTERNS" >&2 || :
+    rm -f "$TARBALL"
+    notify-send -u critical "Xibo debug dump" "Aborted — sensitive path detected" 2>/dev/null || true
+    exit 10
+fi
+
+SIZE=$(du -h "$TARBALL" 2>/dev/null | cut -f1)
+echo "xibo-debug-dump: wrote $TARBALL ($SIZE)"
+
+# --- notify the user ------------------------------------------------------
+# notify-send reaches dunst if we're in the xibo kiosk session. Always
+# print to stderr as well in case this script is run from a non-graphical
+# context (e.g. SSH or a systemd unit with no DISPLAY).
+if command -v notify-send >/dev/null 2>&1; then
+    notify-send -t 15000 "Xibo debug dump" \
+        "$TARBALL ($SIZE)
+Copy to USB or email to support." 2>/dev/null || true
+fi
+
+# Also show zenity dialog if we're in a graphical session and zenity is
+# available. Skip silently if not — the notify-send above is enough.
+if [ -n "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ] && command -v zenity >/dev/null 2>&1; then
+    zenity --info --title="Xibo debug dump" --width=500 \
+        --text="Debug bundle created:
+
+$TARBALL ($SIZE)
+
+Copy to a USB stick or email to support.
+Sensitive values (CMS keys, Wi-Fi passwords) have been redacted." \
+        2>/dev/null || true
+fi
+
+echo "xibo-debug-dump: done"
+exit 0

--- a/rpm/xiboplayer-kiosk.spec
+++ b/rpm/xiboplayer-kiosk.spec
@@ -1,5 +1,5 @@
 Name:           xiboplayer-kiosk
-Version:        0.4.22
+Version:        0.4.23
 Release:        1%{?dist}
 Summary:        Kiosk session scripts for Xibo digital signage players
 
@@ -67,6 +67,13 @@ install -Dm755 kiosk/xibo-deactivate-kiosk.sh %{buildroot}%{_datadir}/xiboplayer
 # by root from kickstart %post). Never passes the PSK on the nmcli CLI,
 # closing the /proc/<pid>/cmdline leak window.
 install -Dm755 kiosk/xibo-set-wifi.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-set-wifi.sh
+# Issue #70 — support bundle collector (Ctrl+D via keyd, zenity row in
+# the first-boot + reconfigure menus, /usr/bin/xibo-debug-dump CLI).
+install -Dm755 kiosk/xibo-debug-dump.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-debug-dump.sh
+# /usr/bin/xibo-debug-dump symlink so technicians can run it from an
+# SSH session by just typing `xibo-debug-dump`.
+install -d %{buildroot}%{_bindir}
+ln -sf %{_datadir}/xiboplayer-kiosk/xibo-debug-dump.sh %{buildroot}%{_bindir}/xibo-debug-dump
 
 # System config files — the kiosk RPM IS the kiosk definition, so the
 # system-level config that makes a kiosk stay on forever + suppresses the
@@ -102,6 +109,8 @@ install -m755 kiosk/gnome-kiosk-script.sh %{buildroot}%{_sysconfdir}/skel/.local
 %{_datadir}/xiboplayer-kiosk/xibo-activate-kiosk.sh
 %{_datadir}/xiboplayer-kiosk/xibo-deactivate-kiosk.sh
 %{_datadir}/xiboplayer-kiosk/xibo-set-wifi.sh
+%{_datadir}/xiboplayer-kiosk/xibo-debug-dump.sh
+%{_bindir}/xibo-debug-dump
 %{_sysconfdir}/keyd/xibo.conf
 %{_sysconfdir}/yum.repos.d/copr-keyd.repo
 %{_sysconfdir}/skel/.local/bin/gnome-kiosk-script
@@ -124,6 +133,30 @@ install -m755 kiosk/gnome-kiosk-script.sh %{buildroot}%{_sysconfdir}/skel/.local
 /usr/bin/dconf update &>/dev/null || :
 
 %changelog
+* Sat Apr 11 2026 Pau Aliagas <linuxnow@gmail.com> - 0.4.23-1
+- Support bundle collector xibo-debug-dump.sh (#70). Gathers logs
+  (journalctl user + kernel + services), configs (preseed.env, player
+  config.json, cms.json, setup-result.json), hardware inventory
+  (lscpu, lspci, lsusb, lsblk, GPU), NetworkManager state, timedate,
+  locale, and kiosk-specific state (firstboot sentinels, alternatives,
+  logind.conf) into a zstd-compressed tarball at
+  \$HOME/Downloads/xibo-debug-<hostname>-<timestamp>.tar.zst.
+- Sensitive values (CMS keys, Wi-Fi PSKs, basic-auth URL credentials)
+  redacted before staging via an inline _redact() helper with 5 sed
+  patterns. Post-tar SECURITY assertion refuses to ship the bundle if
+  any NetworkManager keyfile, /etc/shadow, browser Cookies directory,
+  doas.conf, or .ssh/id_ private key sneaks in — deletes the tarball
+  and fires a critical notify-send.
+- Three triggers: Ctrl+D via keyd (new d = command(...) binding in
+  kiosk/keyd-xibo.conf); direct CLI via the new /usr/bin/xibo-debug-
+  dump symlink; zenity menu row (wired up in #67). A fourth trigger
+  — labeled-USB auto-collect via udev — is supported via
+  xibo-debug-dump --to-usb but the udev rule itself is not yet
+  installed (follow-up).
+- notify-send + zenity --info confirmation dialog show the tarball
+  path and size when the collection succeeds, so non-technical
+  operators know where to find the file.
+
 * Sat Apr 11 2026 Pau Aliagas <linuxnow@gmail.com> - 0.4.22-1
 - iPXE / kernel preseed infrastructure + best-available-disk autodetect
   (#68). Kickstart %post now parses every xibo.* kernel param, fetches


### PR DESCRIPTION
Closes #70. Bumps 0.4.22 → 0.4.23.

New `/usr/bin/xibo-debug-dump` command writes a zstd-compressed tarball of kiosk diagnostic state to `$HOME/Downloads/xibo-debug-<hostname>-<timestamp>.tar.zst`. MSP technicians can collect it locally via Ctrl+D, from an SSH session by typing `xibo-debug-dump`, or from the zenity reconfigure menu (#67 will add the menu row).

See CHANGELOG.md entry for 0.4.23 for the full list of 15 collected files, the redaction patterns, the post-tar security assertion, and the four triggers.

## Triggers shipped in this PR

- **Ctrl+D via keyd** — new `d = command(...)` binding in `kiosk/keyd-xibo.conf` (wraps via the existing xibo-keyd-run.sh so graphical env is correct)
- **CLI** — `/usr/bin/xibo-debug-dump` symlink created by RPM spec and deb build script
- **Labeled USB auto-collect** — `xibo-debug-dump --to-usb` looks for a mounted filesystem labeled `XIBO-DEBUG` via `findmnt`; matching udev rule for auto-trigger on plug-in is deferred

## Triggers deferred to other issues

- **Zenity menu row** — #67 will wire up the menu row when xibo-first-boot.sh and the updated xibo-show-cms.sh land

## Test plan

- [ ] Run `xibo-debug-dump` on a Fedora box, verify tarball in `~/Downloads`, inspect contents, confirm no PSKs or CMS keys
- [ ] `tar --zstd -tf $TARBALL | grep -E 'system-connections|/shadow|Cookies|doas.conf|id_rsa'` returns nothing
- [ ] Ctrl+D in a kiosk session triggers the script (via keyd)
- [ ] `xibo-debug-dump --to-usb` with no labeled USB exits 3 with a critical notify
- [ ] rpmbuild succeeds with the new Source + %files entries
- [ ] deb build succeeds with the new install + symlink steps

Closes #70.