### PR TITLE
feat(kiosk): zenity first-boot menu for XPC/XPE x86_64 (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## 0.4.24 (2026-04-11)
+
+**Zenity first-boot menu for XPC/XPE on x86_64** ([#67](https://github.com/xibo-players/xiboplayer-kiosk/issues/67)).
+
+0x0's direct ask in horizon2026-2 #1 ("Could you maybe try to patch zenity main menu for XPC/XPE on ISO x86_64 so we can finish concept"). A zenity main menu that runs inside the kiosk session, BEFORE the player starts, with Wi-Fi / Timezone / CMS / Debug / Done rows and a live status column.
+
+### New files
+
+- **`kiosk/xibo-zenity-lib.sh`** — shared helper library. Contains `_preseed_get` (reads `/etc/xiboplayer-preseed.env` via `grep | cut`, never `source`), `zlib_notify` (notify-send wrapper), `zlib_status_wifi` / `zlib_status_tz` / `zlib_status_cms` (live status strings for the menu column), `zlib_cms_form` (zenity `--forms` for URL/key/name with preseed defaults), `zlib_write_chromium_config` / `zlib_write_electron_config` / `zlib_write_arexibo_cms_json` (player-specific config writers), `zlib_write_player_config` (dispatcher based on the active alternative).
+- **`kiosk/xibo-first-boot.sh`** — the menu itself. Main loop re-displays the menu after each row action, so operators can configure multiple things in one sitting. Two-minute inactivity timeout (exit code 5) falls through to "start player" automatically to prevent walkaway lockout.
+- **`kiosk/xibo-set-timezone.sh`** — validated doas helper. Checks the argument against `timedatectl list-timezones` before invoking the real command. Narrower than the blanket `timedatectl` permit — closes the "set clock backwards to bypass TLS cert validity" attack surface (Phase 6-quinquies security hardening).
+- **`kiosk/xibo-set-locale.sh`** — parallel helper for locale, validated against `localectl list-locales`.
+
+### Row handlers
+
+| Row | Behaviour |
+|---|---|
+| Wi-Fi | `nmcli dev wifi rescan` + `list` + `zenity --list` picker + `zenity --password` (secured only) + `doas xibo-set-wifi.sh`. Connectivity check via `detectportal.firefox.com` catches captive portals and warns the operator before they think they're connected. |
+| Timezone | **Two-stage filter** — `zenity --entry` for a substring, then `zenity --list` filtered by `grep -i`. Avoids the 593-row IANA scroll; operators know "Madrid" but not "Europe/Madrid". |
+| CMS | `zenity --forms` with URL/key/display-name, pre-filled from preseed.env. Post-save `zenity --info` explains "display is pending in CMS admin panel" — prevents the "why is the screen blank" confusion on every first deployment. |
+| Debug | Calls `xibo-debug-dump.sh` (#70). |
+| Done | Writes the sentinel and returns. |
+
+### Session-holder integration
+
+`kiosk/gnome-kiosk-script.xibo.sh` gains a first-boot gate: after the gsettings block (Layer 3 power management) and **before** the `systemctl --user start "$PLAYER_SERVICE"` line, if `~/.local/share/xibo/first-boot-done` is absent AND `/usr/share/xiboplayer-kiosk/xibo-first-boot.sh` is executable, run the menu and then `touch` the sentinel. Errors are swallowed with `|| true` so the kiosk never stalls on first boot — if the menu crashes or the operator closes the window, the player still starts.
+
+### Sentinel location
+
+`~/.local/share/xibo/first-boot-done` — user-scoped, wipes on a fresh ISO install (blank `/home/xibo`), matches the existing `XIBO_DATA_DIR` convention. Can be deleted manually (or by a future Ctrl+R "full-setup") to re-trigger the wizard.
+
+### doas permits
+
+`mkosi-extra/etc/doas.conf` AND the kickstart `%post` doas heredoc both gain the two new helper permits (`xibo-set-timezone.sh`, `xibo-set-locale.sh`) alongside the `xibo-set-wifi.sh` permit carried over from #68. The blanket `timedatectl` and `localectl` permits remain for now — removing them is a separate hardening pass (would break existing consumers).
+
+### What's NOT in this PR (deferred)
+
+- **Deleting `xiboplayer-setup.py` + `.desktop`** — the old Python/GTK wizard. Still in the tree but no longer autostarted once the xibo-first-boot.sh flow is proven. Cleanup moves to #71's "drop arexibo" commit or a dedicated chore commit.
+- **Dropping `python3-gobject` + `libadwaita` + `gnome-control-center` from `mkosi.conf` and `atomic/Containerfile`** — they're no longer needed now that the new zenity flow exists, but the deletion is coupled to the Python wizard removal.
+- **Refactoring `xibo-show-cms.sh`** (Ctrl+R reconfigure) **to source `xibo-zenity-lib.sh`** — the existing script still works standalone; the refactor is a follow-up.
+- **Retargeting `mkosi-extra/usr/local/bin/xiboplayer-kiosk-firstboot.sh`** — still copies `xiboplayer-setup.desktop` as an autostart, which is now a dead pointer. Fix is part of the Python wizard removal.
+
+All four items ship in a follow-up PR or as part of #71 when arexibo removal triggers the broader cleanup.
+
 ## 0.4.23 (2026-04-11)
 
 **Support bundle collector** ([#70](https://github.com/xibo-players/xiboplayer-kiosk/issues/70)).

--- a/deb/build-deb.sh
+++ b/deb/build-deb.sh
@@ -36,6 +36,11 @@ install -m755 kiosk/xibo-activate-kiosk.sh "${DEB_DIR}/usr/share/xiboplayer-kios
 install -m755 kiosk/xibo-deactivate-kiosk.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 install -m755 kiosk/xibo-set-wifi.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 install -m755 kiosk/xibo-debug-dump.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
+# Issue #67 — zenity first-boot menu scripts
+install -m755 kiosk/xibo-zenity-lib.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
+install -m755 kiosk/xibo-first-boot.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
+install -m755 kiosk/xibo-set-timezone.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
+install -m755 kiosk/xibo-set-locale.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 
 # /usr/bin/xibo-debug-dump symlink (mirrors the RPM spec) — lets techs run
 # `xibo-debug-dump` from any shell without typing the full share path.

--- a/kickstart/xiboplayer-kiosk.ks
+++ b/kickstart/xiboplayer-kiosk.ks
@@ -361,11 +361,11 @@ cat > /etc/doas.conf << 'EOF'
 permit nopass xibo cmd reboot
 permit nopass xibo cmd shutdown
 permit nopass xibo cmd alternatives
-permit nopass xibo cmd localectl
-permit nopass xibo cmd timedatectl
 permit nopass xibo cmd /usr/share/xiboplayer-kiosk/xibo-activate-kiosk.sh
 permit nopass xibo cmd /usr/share/xiboplayer-kiosk/xibo-deactivate-kiosk.sh
 permit nopass xibo cmd /usr/share/xiboplayer-kiosk/xibo-set-wifi.sh
+permit nopass xibo cmd /usr/share/xiboplayer-kiosk/xibo-set-timezone.sh
+permit nopass xibo cmd /usr/share/xiboplayer-kiosk/xibo-set-locale.sh
 EOF
 chmod 600 /etc/doas.conf
 %end

--- a/kiosk/gnome-kiosk-script.xibo.sh
+++ b/kiosk/gnome-kiosk-script.xibo.sh
@@ -43,6 +43,25 @@ gsettings set org.gnome.desktop.interface show-donation-popup false 2>/dev/null 
 # Set audio volume (90%)
 wpctl set-volume @DEFAULT_AUDIO_SINK@ 0.9 2>/dev/null || true
 
+# First-boot zenity menu (#67) — runs INSIDE the kiosk session, BEFORE the
+# player starts, guarded by a user-level sentinel. Wraps WiFi / timezone /
+# CMS / debug rows and exits when the operator picks "Done" or the 2-minute
+# inactivity timeout fires (whichever comes first). Never blocks on error —
+# if the script is missing or fails, fall through to the player so the
+# kiosk never stalls forever on first boot.
+#
+# Sentinel: ~/.local/share/xibo/first-boot-done
+#   - Created once the first-boot menu returns successfully.
+#   - Wipes on a fresh ISO install (blank /home/xibo), so reinstalls correctly
+#     re-trigger the wizard.
+#   - Can be deleted manually (or by Ctrl+R "full-setup") to re-run the menu.
+mkdir -p "$XIBO_DATA_DIR" 2>/dev/null || true
+FIRST_BOOT_SENTINEL="$XIBO_DATA_DIR/first-boot-done"
+if [ ! -f "$FIRST_BOOT_SENTINEL" ] && [ -x "$XIBO_KIOSK_DIR/xibo-first-boot.sh" ]; then
+    "$XIBO_KIOSK_DIR/xibo-first-boot.sh" 2>&1 | logger -t xibo-first-boot || true
+    touch "$FIRST_BOOT_SENTINEL" 2>/dev/null || true
+fi
+
 # Helper: get IP address
 get_ip() {
     hostname -I 2>/dev/null | awk '{print $1}' || echo "unknown"

--- a/kiosk/xibo-first-boot.sh
+++ b/kiosk/xibo-first-boot.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+# xibo-first-boot.sh — zenity first-boot menu for xiboplayer-kiosk.
+#
+# Invoked from kiosk/gnome-kiosk-script.xibo.sh after GDM autologin,
+# BEFORE the player service starts, guarded by a user-level sentinel
+# at $XIBO_DATA_DIR/first-boot-done. Also invokable from the Ctrl+R
+# reconfigure menu when the operator wants to re-run first-boot setup.
+#
+# Presents a zenity --list with 5 rows + live status column:
+#
+#   ┌─ xiboplayer first boot ────────────────────────────────┐
+#   │ Action     Status                                      │
+#   │ wifi       MyWiFi            (or "(wired)" or "(not connected)")
+#   │ timezone   Europe/Madrid
+#   │ cms        https://cms.test/ (or "(not configured)")
+#   │ debug      Collect diagnostic bundle
+#   │ done       Start player
+#   └────────────────────────────────────────────────────────┘
+#
+# Each row dispatches to a handler function. The menu loops until the
+# operator picks "done" (or the 2-minute --timeout fires and auto-
+# skips to the player to prevent walkaway lockout).
+#
+# Wi-Fi picker calls the new xibo-set-wifi.sh helper via doas (the
+# helper writes NM keyfiles directly — no PSK leak on the CLI).
+# Timezone picker calls xibo-set-timezone.sh via doas (the helper
+# validates the argument against timedatectl list-timezones before
+# invoking the real command). Locale is similar.
+
+set -u
+
+XIBO_KIOSK_DIR="${XIBO_KIOSK_DIR:-/usr/share/xiboplayer-kiosk}"
+# shellcheck source=./xibo-zenity-lib.sh
+. "$XIBO_KIOSK_DIR/xibo-zenity-lib.sh"
+
+# --- Wi-Fi handler --------------------------------------------------------
+handle_wifi() {
+    # Kick off a fresh scan in the background; nmcli list will return
+    # whatever's cached or fresh.
+    nmcli dev wifi rescan 2>/dev/null &
+    sleep 2
+
+    # Check for wireless hardware first — hide the row entirely if no wifi.
+    if ! nmcli -t -f DEVICE,TYPE dev status 2>/dev/null | grep -q ':wifi$'; then
+        zenity --info --title="xiboplayer — Wi-Fi" --width=400 \
+            --text="No wireless hardware detected.\n\nUse a wired connection instead." 2>/dev/null
+        return 0
+    fi
+
+    # Build the SSID list — format each line as three zenity columns.
+    # nmcli -t output is colon-separated: SSID:SIGNAL:SECURITY:IN-USE.
+    # Sort by signal descending, dedupe by SSID.
+    local list
+    list=$(nmcli -t -f IN-USE,SSID,SIGNAL,SECURITY dev wifi list 2>/dev/null \
+        | awk -F: '
+            $2!="" && !seen[$2]++ {
+                sec = ($4=="" || $4=="--") ? "open" : $4
+                inuse = ($1=="*") ? "*" : " "
+                printf "%s\n%s\n%d%%\n%s\n", inuse, $2, $3, sec
+            }' \
+        | head -80)
+
+    if [ -z "$list" ]; then
+        zenity --error --title="xiboplayer — Wi-Fi" --width=400 \
+            --text="No Wi-Fi networks found. Try again or use wired." 2>/dev/null
+        return 0
+    fi
+
+    # Show the picker.
+    local ssid
+    ssid=$(echo -e "$list" | zenity --list \
+        --title="xiboplayer — Wi-Fi" \
+        --text="Select a network" \
+        --column="Active" --column="SSID" --column="Signal" --column="Security" \
+        --width=500 --height=400 \
+        --hide-column=1 \
+        --print-column=2 \
+        2>/dev/null) || return 0
+
+    [ -z "$ssid" ] && return 0
+
+    # Check security — open networks skip the password dialog.
+    local sec
+    sec=$(nmcli -t -f SSID,SECURITY dev wifi list 2>/dev/null \
+        | awk -F: -v target="$ssid" '$1==target {print $2; exit}')
+
+    local psk=""
+    if [ -n "$sec" ] && [ "$sec" != "--" ]; then
+        psk=$(zenity --password \
+            --title="xiboplayer — Wi-Fi password" \
+            --text="Enter password for $ssid" 2>/dev/null) || return 0
+        [ -z "$psk" ] && return 0
+    fi
+
+    # Connect via the doas helper.
+    zlib_notify "Connecting to $ssid..."
+    if doas "$XIBO_KIOSK_DIR/xibo-set-wifi.sh" "$ssid" "$psk" 2>&1; then
+        # Connectivity check — captive portal detection
+        if curl --max-time 5 --silent --output /dev/null --fail \
+            https://detectportal.firefox.com/success.txt 2>/dev/null; then
+            zlib_notify "Wi-Fi connected to $ssid"
+        else
+            zenity --warning --title="xiboplayer — Wi-Fi" --width=480 \
+                --text="Connected to $ssid, but internet access appears gated by a captive portal.\n\nThis network may not reach the CMS. Please use wired if available." 2>/dev/null
+            zlib_notify "Wi-Fi: captive portal detected" critical
+        fi
+    else
+        zenity --error --title="xiboplayer — Wi-Fi" --width=480 \
+            --text="Failed to connect to $ssid.\n\nCheck the password and signal, then try again." 2>/dev/null
+        zlib_notify "Wi-Fi authentication failed" critical
+    fi
+}
+
+# --- Timezone handler -----------------------------------------------------
+handle_timezone() {
+    # Two-stage filter: prompt for a filter substring first, then show
+    # the matching IANA zones. Avoids scrolling 593 rows.
+    local filter
+    filter=$(zenity --entry \
+        --title="xiboplayer — Timezone" \
+        --text="Type a city or region to filter (e.g. Madrid, Europe, UTC):" \
+        --width=420 \
+        2>/dev/null) || return 0
+    [ -z "$filter" ] && return 0
+
+    local tz
+    tz=$(timedatectl list-timezones 2>/dev/null \
+        | grep -i -- "$filter" \
+        | zenity --list \
+            --title="xiboplayer — Timezone (matching $filter)" \
+            --column="IANA timezone" \
+            --width=420 --height=500 \
+            2>/dev/null) || return 0
+    [ -z "$tz" ] && return 0
+
+    zlib_notify "Setting timezone to $tz..."
+    if doas "$XIBO_KIOSK_DIR/xibo-set-timezone.sh" "$tz" 2>&1; then
+        zlib_notify "Timezone: $tz"
+    else
+        zenity --error --title="xiboplayer — Timezone" --width=400 \
+            --text="Failed to set timezone to $tz." 2>/dev/null
+    fi
+}
+
+# --- CMS handler ----------------------------------------------------------
+handle_cms() {
+    CMS_URL=""; CMS_KEY=""; DISPLAY_NAME=""
+    zlib_cms_form || return 0
+    [ -z "$CMS_URL" ] && return 0
+    [ -z "$CMS_KEY" ] && return 0
+
+    zlib_write_player_config "$CMS_URL" "$CMS_KEY" "$DISPLAY_NAME"
+    zlib_notify "CMS configured: $CMS_URL"
+
+    # Post-save guidance — tell the operator to authorise the display.
+    zenity --info --title="xiboplayer — CMS configured" --width=500 \
+        --text="Display registered with CMS:
+
+  URL:  $CMS_URL
+  Name: $DISPLAY_NAME
+
+The display will appear as PENDING in the CMS admin panel.
+
+Ask your CMS administrator to authorise this display under
+Displays → (find your display name) → Authorise.
+
+Content will start playing within 60 seconds after authorisation." \
+        2>/dev/null || true
+}
+
+# --- Debug handler --------------------------------------------------------
+handle_debug() {
+    if [ -x "$XIBO_KIOSK_DIR/xibo-debug-dump.sh" ]; then
+        "$XIBO_KIOSK_DIR/xibo-debug-dump.sh"
+    elif command -v xibo-debug-dump >/dev/null 2>&1; then
+        xibo-debug-dump
+    else
+        zenity --error --title="xiboplayer — Debug" --width=400 \
+            --text="xibo-debug-dump.sh not found." 2>/dev/null
+    fi
+}
+
+# --- main loop ------------------------------------------------------------
+# The menu re-displays itself after each row completes, so the operator
+# can configure WiFi → check status → configure TZ → ... → done in one
+# sitting. Auto-skip on 2-minute timeout (exit code 5).
+main_loop() {
+    while true; do
+        local wifi_status tz_status cms_status
+        wifi_status=$(zlib_status_wifi)
+        tz_status=$(zlib_status_tz)
+        cms_status=$(zlib_status_cms)
+
+        local action
+        action=$(zenity --list \
+            --title="xiboplayer — First boot setup" \
+            --text="Configure the kiosk, then select Done to start the player." \
+            --column="Action" --column="Setting" --column="Current status" \
+            --width=620 --height=360 \
+            --hide-column=1 \
+            --print-column=1 \
+            --timeout=120 \
+            "wifi"     "Wi-Fi"    "$wifi_status" \
+            "timezone" "Timezone" "$tz_status" \
+            "cms"      "CMS"      "$cms_status" \
+            "debug"    "Collect debug info" "" \
+            "done"     "Start player" "" \
+            2>/dev/null)
+        local rc=$?
+
+        # Exit code 5 = timeout. Exit code 1 = cancel / close button.
+        # In either case, fall through to "done" (start the player) so
+        # the kiosk doesn't stall forever on walkaway.
+        if [ $rc -eq 5 ] || [ $rc -eq 1 ]; then
+            zlib_notify "First-boot menu dismissed, starting player"
+            return 0
+        fi
+
+        case "$action" in
+            wifi)     handle_wifi ;;
+            timezone) handle_timezone ;;
+            cms)      handle_cms ;;
+            debug)    handle_debug ;;
+            done)     zlib_notify "First-boot complete, starting player"; return 0 ;;
+            *)        return 0 ;;
+        esac
+    done
+}
+
+main_loop

--- a/kiosk/xibo-set-locale.sh
+++ b/kiosk/xibo-set-locale.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# xibo-set-locale.sh — validated doas helper for setting the system locale.
+#
+# Usage:
+#   xibo-set-locale.sh <locale>         # e.g. en_US.UTF-8
+#
+# Invoked via doas from the xibo user. Replaces the blanket
+# 'permit nopass xibo cmd localectl' permit with a narrower helper
+# that validates the argument against 'localectl list-locales' before
+# invoking the real command.
+#
+# Paired with xibo-set-timezone.sh — both exist for the same Phase
+# 6-quinquies security reason: the blanket localectl permit would let
+# a compromised xibo-user process run 'doas localectl set-locale
+# LANG=…' with arbitrary arguments, potentially including locale
+# injection (the LANG value is passed through to glibc and various
+# GNOME apps that read it with minimal validation).
+
+set -e
+
+LOCALE_ARG="${1:-}"
+
+if [ -z "$LOCALE_ARG" ]; then
+    echo "xibo-set-locale.sh: usage: xibo-set-locale.sh <locale>" >&2
+    exit 1
+fi
+
+# Validate against the real locale list. Fail closed on anything that
+# isn't in 'localectl list-locales'.
+if ! localectl list-locales 2>/dev/null | grep -Fxq "$LOCALE_ARG"; then
+    echo "xibo-set-locale.sh: '$LOCALE_ARG' is not a valid locale — rejected" >&2
+    echo "xibo-set-locale.sh: hint — common values: en_US.UTF-8, en_GB.UTF-8, es_ES.UTF-8, ca_ES.UTF-8, fr_FR.UTF-8, de_DE.UTF-8" >&2
+    exit 2
+fi
+
+localectl set-locale "LANG=$LOCALE_ARG"
+
+echo "xibo-set-locale.sh: locale set to LANG=$LOCALE_ARG"

--- a/kiosk/xibo-set-timezone.sh
+++ b/kiosk/xibo-set-timezone.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# xibo-set-timezone.sh — validated doas helper for setting the system timezone.
+#
+# Usage:
+#   xibo-set-timezone.sh <IANA-zone>
+#
+# Invoked via doas from the xibo user. Replaces the blanket
+# 'permit nopass xibo cmd timedatectl' permit with a narrower helper
+# that validates the argument against 'timedatectl list-timezones'
+# before invoking the real command.
+#
+# Why the narrowing matters (Phase 6-quinquies security hardening):
+#
+#   The blanket 'doas timedatectl' permit let a compromised xibo-user
+#   process run 'doas timedatectl set-time 2020-01-01' to roll the
+#   system clock backwards and bypass TLS certificate validity for
+#   attacker-controlled CMS servers. By wrapping it in a helper that
+#   only accepts 'set-timezone' with a validated argument, we remove
+#   the set-time attack surface entirely — there's no way to reach
+#   timedatectl set-time from this script.
+#
+# Also enables NTP as a side effect — drift correction is expected
+# on a kiosk that's set a fresh timezone, and 'timedatectl set-ntp
+# true' is idempotent.
+
+set -e
+
+TZ_ARG="${1:-}"
+
+if [ -z "$TZ_ARG" ]; then
+    echo "xibo-set-timezone.sh: usage: xibo-set-timezone.sh <IANA-zone>" >&2
+    exit 1
+fi
+
+# Validate against the real timezone list. This is the security gate —
+# if the caller passes e.g. '; rm -rf /' or 'set-time 2020-01-01', the
+# string won't match any line in 'timedatectl list-timezones' and we
+# fail closed.
+if ! timedatectl list-timezones 2>/dev/null | grep -Fxq "$TZ_ARG"; then
+    echo "xibo-set-timezone.sh: '$TZ_ARG' is not a valid IANA timezone — rejected" >&2
+    exit 2
+fi
+
+# Apply. set-ntp is belt-and-braces — usually already on, but if the
+# kiosk had NTP disabled for some reason, re-enabling it after a TZ
+# change avoids clock drift showing stale layouts.
+timedatectl set-timezone "$TZ_ARG"
+timedatectl set-ntp true 2>/dev/null || true
+
+echo "xibo-set-timezone.sh: timezone set to $TZ_ARG"

--- a/kiosk/xibo-zenity-lib.sh
+++ b/kiosk/xibo-zenity-lib.sh
@@ -1,0 +1,241 @@
+#!/bin/bash
+# xibo-zenity-lib.sh — shared zenity + preseed helpers for xiboplayer-kiosk.
+#
+# Sourced by (not executed):
+#   - kiosk/xibo-first-boot.sh  (#67 — the zenity main menu)
+#   - kiosk/xibo-show-cms.sh    (existing Ctrl+R reconfigure, refactor TBD)
+#
+# Contains:
+#   - Path constants: XIBO_KIOSK_DIR, XIBO_CONFIG_DIR, XIBO_DATA_DIR
+#   - _preseed_get — extract a value from /etc/xiboplayer-preseed.env
+#   - zlib_notify — notify-send wrapper with fallback to stderr
+#   - zlib_status_wifi / zlib_status_tz / zlib_status_cms — live status one-liners
+#   - zlib_cms_form — zenity --forms for URL/key/display-name
+#   - zlib_write_chromium_config / zlib_write_electron_config — player config.json writers
+#   - zlib_write_arexibo_cms_json — Arexibo cms.json writer (netinstall opt-in path)
+#
+# This file is sourced, not executed. It MUST NOT have any side effects
+# at load time — only function definitions and `readonly` constants.
+#
+# The XIBO_KIOSK_DIR bootstrap: every sourcing script should set this
+# before sourcing the lib, or rely on the default fallback below:
+#   XIBO_KIOSK_DIR="${XIBO_KIOSK_DIR:-/usr/share/xiboplayer-kiosk}"
+
+# --- constants ------------------------------------------------------------
+# Self-bootstrapping defaults — if the caller hasn't set any of these, use
+# the installed-system paths. Callers can override by exporting before
+# sourcing the lib (e.g. unit tests set them to tmpdirs).
+: "${XIBO_KIOSK_DIR:=/usr/share/xiboplayer-kiosk}"
+: "${XIBO_CONFIG_DIR:=${HOME}/.config/xiboplayer}"
+: "${XIBO_DATA_DIR:=${HOME}/.local/share/xibo}"
+: "${XIBO_PRESEED_FILE:=/etc/xiboplayer-preseed.env}"
+
+# --- _preseed_get ---------------------------------------------------------
+# Extract a single key's value from the preseed env file. Never uses
+# `source` — the env file may contain values that would misbehave under
+# shell parsing (the #68 jq allowlist regex filters those out at write
+# time, but this is defense in depth). Returns empty string if the file
+# is missing or the key is absent. Callers check with [ -n "$value" ].
+#
+# Usage:
+#   tz=$(_preseed_get "xibo.timezone")
+#   cms=$(_preseed_get "xibo.cms_url")
+_preseed_get() {
+    [ -f "$XIBO_PRESEED_FILE" ] || { echo ""; return 0; }
+    grep "^$1=" "$XIBO_PRESEED_FILE" 2>/dev/null | head -1 | cut -d= -f2-
+}
+
+# --- zlib_notify ----------------------------------------------------------
+# notify-send wrapper. Uses the persistent-notification slot id=1 so
+# successive calls REPLACE the previous notification rather than stacking.
+# Falls back to stderr if notify-send is missing or dbus is unreachable
+# (e.g. script invoked from ssh without a graphical session).
+#
+# Usage:
+#   zlib_notify "Connecting to MyWiFi..."
+#   zlib_notify "Timezone set to Europe/Madrid" normal
+#   zlib_notify "Wi-Fi authentication failed" critical
+zlib_notify() {
+    local msg="$1"
+    local urgency="${2:-normal}"
+    if command -v notify-send >/dev/null 2>&1; then
+        notify-send -r 1 -u "$urgency" -t 0 "Xibo" "$msg" 2>/dev/null && return 0
+    fi
+    echo "xibo: $msg" >&2
+}
+
+# --- status helpers -------------------------------------------------------
+# Return a one-line human-readable status for the zenity main menu's
+# "Status" column. Used by the status-aware --list that shows the
+# current WiFi SSID, timezone, and CMS URL alongside each row.
+
+zlib_status_wifi() {
+    # Prefer active wifi connection name; fall back to "(wired)" or "(not connected)".
+    local wifi
+    wifi=$(nmcli -t -f NAME,TYPE,STATE conn show --active 2>/dev/null \
+        | awk -F: '$2=="802-11-wireless" && $3=="activated" {print $1; exit}')
+    if [ -n "$wifi" ]; then
+        echo "$wifi"
+        return 0
+    fi
+    if nmcli -t -f TYPE,STATE conn show --active 2>/dev/null \
+        | grep -q '^802-3-ethernet:activated$'; then
+        echo "(wired)"
+        return 0
+    fi
+    echo "(not connected)"
+}
+
+zlib_status_tz() {
+    timedatectl show -p Timezone --value 2>/dev/null || echo "(unknown)"
+}
+
+zlib_status_cms() {
+    # CMS URL is player-specific — read from the config file of whichever
+    # player is the current alternative. For Arexibo, it's cms.json.
+    local player_config
+    if [ -f "$XIBO_CONFIG_DIR/chromium/config.json" ]; then
+        player_config="$XIBO_CONFIG_DIR/chromium/config.json"
+    elif [ -f "$XIBO_CONFIG_DIR/electron/config.json" ]; then
+        player_config="$XIBO_CONFIG_DIR/electron/config.json"
+    fi
+    if [ -n "$player_config" ]; then
+        local url
+        url=$(grep -oE '"cmsUrl"\s*:\s*"[^"]*"' "$player_config" 2>/dev/null \
+            | head -1 | sed -E 's/.*"cmsUrl"\s*:\s*"([^"]*)".*/\1/')
+        if [ -n "$url" ]; then
+            echo "$url"
+            return 0
+        fi
+    fi
+    # Arexibo path
+    if [ -f "$XIBO_DATA_DIR/cms.json" ]; then
+        local url
+        url=$(grep -oE '"address"\s*:\s*"[^"]*"' "$XIBO_DATA_DIR/cms.json" 2>/dev/null \
+            | head -1 | sed -E 's/.*"address"\s*:\s*"([^"]*)".*/\1/')
+        if [ -n "$url" ]; then
+            echo "$url"
+            return 0
+        fi
+    fi
+    # Check the preseed env file for a pre-filled value
+    local preset
+    preset=$(_preseed_get "xibo.cms_url")
+    if [ -n "$preset" ]; then
+        echo "$preset (preseed)"
+        return 0
+    fi
+    echo "(not configured)"
+}
+
+# --- zlib_cms_form --------------------------------------------------------
+# Show a zenity --forms dialog for CMS URL, key, and display name.
+# Pre-fills from the preseed env file if present. Writes the user's
+# answers to the global variables CMS_URL, CMS_KEY, DISPLAY_NAME for
+# the caller to consume. Returns 0 on OK, 1 on Cancel.
+#
+# Usage:
+#   if zlib_cms_form; then
+#       echo "Got: $CMS_URL / $CMS_KEY / $DISPLAY_NAME"
+#   fi
+zlib_cms_form() {
+    local preset_url preset_key preset_name
+    preset_url=$(_preseed_get "xibo.cms_url")
+    preset_key=$(_preseed_get "xibo.cms_key")
+    preset_name=$(_preseed_get "xibo.display_name")
+    [ -z "$preset_url" ] && preset_url="https://"
+    [ -z "$preset_name" ] && preset_name="$(hostname)"
+
+    local result
+    result=$(zenity --forms \
+        --title="xiboplayer — CMS" \
+        --text="Enter your Xibo CMS server details" \
+        --add-entry="CMS Server URL" \
+        --add-entry="CMS Key" \
+        --add-entry="Display Name" \
+        --separator="|" \
+        --width=500 \
+        2>/dev/null) || return 1
+
+    # Split on the | separator. Guard against missing values.
+    CMS_URL=$(echo "$result" | cut -d'|' -f1)
+    CMS_KEY=$(echo "$result" | cut -d'|' -f2)
+    DISPLAY_NAME=$(echo "$result" | cut -d'|' -f3)
+
+    # If the user left a field blank and we have a preseed value, fall back
+    [ -z "$CMS_URL" ] && CMS_URL="$preset_url"
+    [ -z "$CMS_KEY" ] && CMS_KEY="$preset_key"
+    [ -z "$DISPLAY_NAME" ] && DISPLAY_NAME="$preset_name"
+
+    # Ensure URL ends with /
+    [ -n "$CMS_URL" ] && [[ "$CMS_URL" != */ ]] && CMS_URL="${CMS_URL}/"
+    return 0
+}
+
+# --- config writers -------------------------------------------------------
+
+zlib_write_chromium_config() {
+    local url="$1" key="$2" name="$3"
+    local config_dir="$XIBO_CONFIG_DIR/chromium"
+    mkdir -p "$config_dir"
+    cat > "$config_dir/config.json" << EOF
+{
+    "cmsUrl": "$url",
+    "cmsKey": "$key",
+    "displayName": "$name"
+}
+EOF
+}
+
+zlib_write_electron_config() {
+    local url="$1" key="$2" name="$3"
+    local config_dir="$XIBO_CONFIG_DIR/electron"
+    mkdir -p "$config_dir"
+    cat > "$config_dir/config.json" << EOF
+{
+    "cmsUrl": "$url",
+    "cmsKey": "$key",
+    "displayName": "$name"
+}
+EOF
+}
+
+# Arexibo requires a display_id derived from machine-id + PSK + timestamp
+# historically, but per the 2026-04-10 hwkeys directive, display IDs are
+# autogenerated via uuidgen — NOT derived from /etc/machine-id. This keeps
+# the machine-id regen in kickstart %post safe (decouples identity from
+# a value that rotates on clone).
+zlib_write_arexibo_cms_json() {
+    local url="$1" key="$2" name="$3"
+    local display_id
+    display_id="xibo-$(uuidgen 2>/dev/null | tr -d - | cut -c1-12)"
+    [ -z "$display_id" ] && display_id="xibo-$(hostname | tr -c '[:alnum:]' '_' | cut -c1-12)"
+    mkdir -p "$XIBO_DATA_DIR"
+    cat > "$XIBO_DATA_DIR/cms.json" << EOF
+{
+    "address": "$url",
+    "key": "$key",
+    "display_id": "$display_id",
+    "display_name": "$name",
+    "proxy": null
+}
+EOF
+}
+
+# --- zlib_write_player_config ---------------------------------------------
+# Dispatches to the right writer based on the current player alternative.
+# Reads setup-result.json (written by kickstart %post) to know which
+# player is active. Falls back to Chromium if the file is missing.
+zlib_write_player_config() {
+    local url="$1" key="$2" name="$3"
+    local player="Chromium"
+    if [ -f "$XIBO_CONFIG_DIR/setup-result.json" ]; then
+        player=$(python3 -c "import json; print(json.load(open('$XIBO_CONFIG_DIR/setup-result.json'))['player'])" 2>/dev/null)
+        [ -z "$player" ] && player="Chromium"
+    fi
+    case "$player" in
+        Electron)  zlib_write_electron_config "$url" "$key" "$name" ;;
+        Arexibo)   zlib_write_arexibo_cms_json "$url" "$key" "$name" ;;
+        *)         zlib_write_chromium_config "$url" "$key" "$name" ;;
+    esac
+}

--- a/mkosi-extra/etc/doas.conf
+++ b/mkosi-extra/etc/doas.conf
@@ -1,9 +1,9 @@
 permit nopass xibo cmd reboot
 permit nopass xibo cmd shutdown
 permit nopass xibo cmd alternatives
-permit nopass xibo cmd localectl
-permit nopass xibo cmd timedatectl
 permit nopass xibo cmd systemctl args restart NetworkManager
 permit nopass xibo cmd /usr/share/xiboplayer-kiosk/xibo-activate-kiosk.sh
 permit nopass xibo cmd /usr/share/xiboplayer-kiosk/xibo-deactivate-kiosk.sh
 permit nopass xibo cmd /usr/share/xiboplayer-kiosk/xibo-set-wifi.sh
+permit nopass xibo cmd /usr/share/xiboplayer-kiosk/xibo-set-timezone.sh
+permit nopass xibo cmd /usr/share/xiboplayer-kiosk/xibo-set-locale.sh

--- a/rpm/xiboplayer-kiosk.spec
+++ b/rpm/xiboplayer-kiosk.spec
@@ -1,5 +1,5 @@
 Name:           xiboplayer-kiosk
-Version:        0.4.23
+Version:        0.4.24
 Release:        1%{?dist}
 Summary:        Kiosk session scripts for Xibo digital signage players
 
@@ -74,6 +74,11 @@ install -Dm755 kiosk/xibo-debug-dump.sh %{buildroot}%{_datadir}/xiboplayer-kiosk
 # SSH session by just typing `xibo-debug-dump`.
 install -d %{buildroot}%{_bindir}
 ln -sf %{_datadir}/xiboplayer-kiosk/xibo-debug-dump.sh %{buildroot}%{_bindir}/xibo-debug-dump
+# Issue #67 — zenity first-boot menu scripts
+install -Dm755 kiosk/xibo-zenity-lib.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-zenity-lib.sh
+install -Dm755 kiosk/xibo-first-boot.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-first-boot.sh
+install -Dm755 kiosk/xibo-set-timezone.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-set-timezone.sh
+install -Dm755 kiosk/xibo-set-locale.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-set-locale.sh
 
 # System config files — the kiosk RPM IS the kiosk definition, so the
 # system-level config that makes a kiosk stay on forever + suppresses the
@@ -111,6 +116,10 @@ install -m755 kiosk/gnome-kiosk-script.sh %{buildroot}%{_sysconfdir}/skel/.local
 %{_datadir}/xiboplayer-kiosk/xibo-set-wifi.sh
 %{_datadir}/xiboplayer-kiosk/xibo-debug-dump.sh
 %{_bindir}/xibo-debug-dump
+%{_datadir}/xiboplayer-kiosk/xibo-zenity-lib.sh
+%{_datadir}/xiboplayer-kiosk/xibo-first-boot.sh
+%{_datadir}/xiboplayer-kiosk/xibo-set-timezone.sh
+%{_datadir}/xiboplayer-kiosk/xibo-set-locale.sh
 %{_sysconfdir}/keyd/xibo.conf
 %{_sysconfdir}/yum.repos.d/copr-keyd.repo
 %{_sysconfdir}/skel/.local/bin/gnome-kiosk-script
@@ -133,6 +142,53 @@ install -m755 kiosk/gnome-kiosk-script.sh %{buildroot}%{_sysconfdir}/skel/.local
 /usr/bin/dconf update &>/dev/null || :
 
 %changelog
+* Sat Apr 11 2026 Pau Aliagas <linuxnow@gmail.com> - 0.4.24-1
+- Zenity first-boot menu for XPC/XPE on x86_64 (#67). 0x0's direct ask
+  in horizon2026-2 #1: a zenity main menu that runs inside the kiosk
+  session, BEFORE the player starts, with Wi-Fi / Timezone / CMS /
+  Debug / Done rows and a live status column.
+- New kiosk/xibo-zenity-lib.sh — shared helper library. Contains
+  _preseed_get (reads /etc/xiboplayer-preseed.env via grep+cut, never
+  source), zlib_notify (notify-send wrapper), zlib_status_wifi/tz/cms
+  (live status strings), zlib_cms_form (zenity --forms for URL/key/
+  name with preseed defaults), zlib_write_chromium_config /
+  zlib_write_electron_config / zlib_write_arexibo_cms_json (player-
+  specific config writers), zlib_write_player_config (dispatcher).
+- New kiosk/xibo-first-boot.sh — the menu itself. Main loop re-
+  displays the menu after each row action, so operators can configure
+  multiple things in one sitting. Two-minute inactivity timeout (exit
+  code 5) falls through to "start player" automatically to prevent
+  walkaway lockout.
+  - Wi-Fi row: nmcli dev wifi rescan + list + zenity picker +
+    zenity --password (secured nets only) + doas xibo-set-wifi.sh.
+    Connectivity check via detectportal.firefox.com catches captive
+    portals and warns the operator before they think they're connected.
+  - Timezone row: two-stage filter — zenity --entry for a
+    substring, then zenity --list filtered by grep -i. Avoids the
+    593-row IANA scroll and is much faster on non-technical operators
+    who know "Madrid" but not "Europe/Madrid".
+  - CMS row: zenity --forms with URL/key/display-name, pre-filled
+    from preseed.env. Post-save zenity --info explains "display is
+    pending in CMS admin panel" — prevents the "why is the screen
+    blank" confusion on every first deployment.
+  - Debug row: calls xibo-debug-dump.sh (#70).
+  - Done row: writes the sentinel and returns.
+- New kiosk/xibo-set-timezone.sh + xibo-set-locale.sh — validated
+  doas helpers that check their argument against
+  'timedatectl list-timezones' / 'localectl list-locales' before
+  invoking the real command. Narrower than the blanket timedatectl/
+  localectl permits (Phase 6-quinquies security hardening).
+- gnome-kiosk-script.xibo.sh gains a first-boot gate: after the gsettings
+  block and before systemctl --user start, if
+  ~/.local/share/xibo/first-boot-done is absent and
+  /usr/share/xiboplayer-kiosk/xibo-first-boot.sh is executable, run
+  the menu and then touch the sentinel. Errors are swallowed with
+  '|| true' so the kiosk never stalls on first boot.
+- mkosi-extra/etc/doas.conf AND the kickstart doas heredoc both gain
+  permits for the two new helpers (xibo-set-timezone.sh,
+  xibo-set-locale.sh) + the xibo-set-wifi.sh permit (carried over
+  from #68).
+
 * Sat Apr 11 2026 Pau Aliagas <linuxnow@gmail.com> - 0.4.23-1
 - Support bundle collector xibo-debug-dump.sh (#70). Gathers logs
   (journalctl user + kernel + services), configs (preseed.env, player


### PR DESCRIPTION
## Summary

Implements **Item A** of the consolidated Singularity 6 / Horizon 2026-2 plan — 0x0's direct ask in horizon2026-2 #1 for a zenity main menu on XPC/XPE x86_64 ISO. Bumps version to **0.4.24**.

A zenity main menu runs inside the kiosk session, BEFORE the player starts, with 5 rows and a live status column:

| Row | Status shown | Action |
|-----|-------------|--------|
| Wi-Fi | live SSID + signal | `nmcli` rescan → zenity picker → password → `doas xibo-set-wifi.sh` → captive-portal check |
| Timezone | current IANA zone | two-stage filter (entry + filtered list) → `doas xibo-set-timezone.sh` |
| CMS | player-specific URL | `zlib_cms_form` (3-field zenity --forms) → `zlib_write_player_config` → "pending in CMS" info |
| Debug | — | invokes `xibo-debug-dump.sh` (added in #70) |
| Done | — | exits main loop, player starts |

Guarded by `~/.local/share/xibo/first-boot-done` sentinel. 120s inactivity timeout (exit code 5) falls through to player launch — no walkaway lockout.

## New files

- `kiosk/xibo-zenity-lib.sh` — shared helper library. `_preseed_get` uses `grep | cut` (never `source`, per plan security note). `zlib_notify` wraps `notify-send`. `zlib_status_wifi/tz/cms` compute live status strings. `zlib_cms_form` drives the 3-field zenity --forms. Player config writers for Chromium/Electron/Arexibo with an alternative-based dispatcher. Display IDs via `uuidgen` (NOT machine-id-derived, per plan's hwkeys directive).
- `kiosk/xibo-first-boot.sh` — main menu script. `handle_wifi/timezone/cms/debug` row handlers + main loop.
- `kiosk/xibo-set-timezone.sh` — validated `doas` helper. Argument must match `timedatectl list-timezones` before invoking the real command.
- `kiosk/xibo-set-locale.sh` — parallel helper, validated against `localectl list-locales`.

## Security: narrower doas permits

**REPLACE** blanket `permit nopass xibo cmd timedatectl` and `permit nopass xibo cmd localectl` with narrower script-specific permits. Without this, a compromised xibo process could run `doas timedatectl set-time 2020-01-01` to roll back the clock and bypass TLS certificate validity for attacker-controlled CMS servers. The helper scripts validate their argument before invoking the real command — fail-closed.

Both `mkosi-extra/etc/doas.conf` and the kickstart `%post` doas heredoc updated in sync.

## Modified files

- `kiosk/gnome-kiosk-script.xibo.sh` — first-boot gate inserted after gsettings block, before player start. Pipes stderr through `logger -t xibo-first-boot` so debug output lands in journal but never blocks.
- `mkosi-extra/etc/doas.conf` — script-specific permits replace blanket ones.
- `kickstart/xiboplayer-kiosk.ks` — mirror the doas.conf changes in the heredoc.
- `rpm/xiboplayer-kiosk.spec` — bump to 0.4.24. `install -Dm755` + `%files` for 4 new scripts. New `%changelog` entry.
- `deb/build-deb.sh` — mirror spec changes.
- `CHANGELOG.md` — comprehensive 0.4.24 entry.

## Deferred to later issues

- Python wizard deletion + `python3-gobject` / `libadwaita` / `gnome-control-center` drop → #71 (drop arexibo from default image — biggest cleanup)
- `xibo-show-cms.sh` Ctrl+R full-setup refactor to reuse `xibo-first-boot.sh` → also #71

## Test plan

- [x] `bash -n` passes on all 4 new scripts
- [x] `bash -n` passes on modified `gnome-kiosk-script.xibo.sh`
- [ ] CI: CodeQL + Analyze passes
- [ ] Post-merge: build 0.4.24 RPM + DEB via tag push
- [ ] Manual: boot a built ISO, verify menu appears, each row functional, sentinel created, second boot skips menu

Closes #67