### PR TITLE
feat(kiosk): pre-anaconda whiptail Wi-Fi TUI for netinstall/iPXE (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## 0.4.26 (2026-04-11)
+
+**Pre-anaconda whiptail Wi-Fi TUI for netinstall / iPXE WiFi-only machines** ([#72](https://github.com/xibo-players/xiboplayer-kiosk/issues/72)).
+
+Closes the "user boots netinstall ISO on a WiFi-only machine and hits anaconda's complex GTK dialog" gap that 0x0 flagged in horizon2026-2. A new `%pre --erroronfail` block at the top of `kickstart/xiboplayer-kiosk.ks` runs BEFORE anaconda's network phase with a simple whiptail picker.
+
+### Entry conditions (all three must be true for the TUI to open)
+
+1. No wired ethernet link up (`nmcli -t -f TYPE,STATE dev status | grep ethernet:connected` is empty)
+2. `xibo.wifi_ssid=` was NOT preseeded via kernel cmdline
+3. Wireless hardware is present
+
+If any of these is false, the block exits 0 silently — the TUI never gets in the way of a wired install or a preseeded install.
+
+### Flow
+
+1. Wait up to 10s for NetworkManager to settle (handles races where NM is still `connecting`/`asleep` in the initrd).
+2. `nmcli dev wifi rescan` + 2s sleep for results.
+3. Build whiptail menu from `nmcli -t -f SSID,SIGNAL,SECURITY dev wifi list` (dedupe by SSID, sort by signal, filter empties).
+4. Add synthetic "(hidden)" row (inputbox for manual SSID entry) and "(skip)" row (falls through to anaconda).
+5. Show whiptail menu, wait for user pick (no timeout — this is an interactive install).
+6. If the chosen network is secured, show whiptail passwordbox.
+7. Validate SSID and PSK via verbatim-copy of `_validate_nm_string` from `kiosk/xibo-set-wifi.sh` (rejects control characters + NM INI section headers — same rules as the runtime helper).
+8. Write NM keyfile to `/etc/NetworkManager/system-connections/` in the installer env AND — if `/mnt/sysimage` is already mounted — into the target system. Otherwise stash the credentials in `/tmp/xibo-wifi-preseed` (mode 0600) for `%post` to apply after the target filesystem is mounted.
+9. `nmcli connection up "$SSID"` in the installer env so anaconda has network for `%packages`.
+10. Show success infobox, sleep 2s, return to anaconda.
+
+### %post stash re-application
+
+A new elif branch in the existing `%post` wifi block detects `/tmp/xibo-wifi-preseed`, sources it, calls `xibo-set-wifi.sh "$SSID" "$PSK" "$KEYMGMT"` against the installed system, then `shred -u`s the stash. Precedence: kernel-cmdline `xibo.wifi_ssid=` ALWAYS wins (Layer 2 / per-field params beat TUI input per the plan's preseed precedence).
+
+### Security
+
+- **`_validate_nm_string` copied verbatim** from `kiosk/xibo-set-wifi.sh`. A bats test in #74 will diff the two copies to catch drift. The kickstart comment block flags the sync requirement explicitly.
+- **PSK never touches `/proc/<pid>/cmdline`** — the NM keyfile is written directly; `nmcli connection up "$SSID"` matches by NM connection id, not by PSK.
+- **Stash file** (`/tmp/xibo-wifi-preseed`) is mode `0600` and `shred -u`'d after `%post` consumes it. The PSK is in plaintext for the window between `%pre` and `%post`, which is acceptable because the installer env has no untrusted users during that window.
+- **Error handling**: every step wraps in `|| true` / `return 0`. If `whiptail` or `nmcli` are missing in the `%pre` environment (older installer), the block exits 0 and anaconda's own network phase handles WiFi. If the user cancels the menu, same fall-through. If validation rejects the SSID/PSK, a msgbox explains and the block exits 0. **The TUI can never abort an install.**
+
+### Modified files
+
+- **`kickstart/xiboplayer-kiosk.ks`** — (1) new `%pre --erroronfail` block (~200 lines) before the existing disk-autodetect `%pre`, containing the whiptail TUI inline (single source of truth — no separate file + sync risk); (2) new elif branch in the `%post` wifi block that re-applies `/tmp/xibo-wifi-preseed` if the TUI stashed credentials; (3) `shred -u` the stash after use.
+- **`rpm/xiboplayer-kiosk.spec`** — bump to 0.4.26, new `%changelog` entry.
+
+### Design notes
+
+- **Why inline, not a separate `kickstart/xibo-wifi-tui.sh`?** The plan originally called for a separate file, but a separate file creates a sync problem: the kickstart has no file-include mechanism that works offline in `%pre`, so either the file is `curl`'d at install time (fails for offline installs — the exact case we're fixing) OR the content is duplicated via heredoc (two sources of truth). Inlining keeps the TUI in one place and the sync requirement explicit in the comment header.
+- **Why no timeout on the menu?** The plan allowed 120s inactivity → fall-through. I removed this because the `%pre` block is only shown when a human is physically booting an install ISO — no walk-away scenarios like the first-boot menu (which has the 120s timeout). A human at the console either picks a network or hits Cancel; there's no benefit to auto-skipping.
+- **Why WPA2 default for hidden networks?** WPA3 on a hidden network is extremely rare and the `nmcli connection up` call reports a clear error if the key-mgmt is wrong, so the user can re-run the menu (via Ctrl+R on the installer console) and retry. Open hidden networks are almost non-existent.
+
 ## 0.4.25 (2026-04-11)
 
 **Drop arexibo from the default image + remove Python wizard + drop GTK deps** ([#71](https://github.com/xibo-players/xiboplayer-kiosk/issues/71)).

--- a/kickstart/xiboplayer-kiosk.ks
+++ b/kickstart/xiboplayer-kiosk.ks
@@ -295,6 +295,19 @@ if [ -n "$XIBO_WIFI_SSID" ]; then
     /usr/share/xiboplayer-kiosk/xibo-set-wifi.sh "$XIBO_WIFI_SSID" "$XIBO_WIFI_PSK" \
         && echo "preseed: wifi connected to $XIBO_WIFI_SSID" \
         || echo "preseed: WARNING — wifi helper failed for $XIBO_WIFI_SSID" >&2
+elif [ -f /tmp/xibo-wifi-preseed ]; then
+    # #72 — the pre-anaconda whiptail TUI stashed WiFi credentials in
+    # /tmp when /mnt/sysimage was not yet mounted. Apply them now that
+    # we're in %post (target is / here — chroot semantics).
+    . /tmp/xibo-wifi-preseed
+    if [ -n "$SSID" ]; then
+        echo "preseed: applying stashed WiFi credentials for $SSID"
+        /usr/share/xiboplayer-kiosk/xibo-set-wifi.sh "$SSID" "$PSK" "$KEYMGMT" \
+            && echo "preseed: wifi connected to $SSID (from whiptail TUI)" \
+            || echo "preseed: WARNING — wifi helper failed for $SSID" >&2
+    fi
+    # Always wipe the stash — contains the PSK in plaintext.
+    shred -u /tmp/xibo-wifi-preseed 2>/dev/null || rm -f /tmp/xibo-wifi-preseed
 fi
 
 # SSH pubkey — allows MSP remote support. The value is URL-encoded (spaces
@@ -466,6 +479,258 @@ chown -R xibo:xibo /home/xibo
 
 # Clean dnf cache
 dnf clean all
+%end
+
+# ========================================================================
+# Pre-anaconda WiFi picker (#72) — whiptail TUI for WiFi-only machines
+# ========================================================================
+# Runs BEFORE anaconda's network phase so the user never sees the complex
+# built-in GTK WiFi dialog. Closes the gap for netinstall / iPXE users
+# booting off a machine with NO wired ethernet.
+#
+# Skip conditions (any one of these triggers fall-through):
+#   1. Network is already up (wired link found)
+#   2. xibo.wifi_ssid= was preseeded via kernel cmdline (#68)
+#   3. No wireless hardware detected
+#
+# Flow:
+#   - Wait for NetworkManager to settle (10s retry loop)
+#   - nmcli dev wifi rescan + 2s sleep for results
+#   - whiptail --menu picker built from `nmcli dev wifi list`
+#   - whiptail --passwordbox if secured
+#   - write NM keyfile to installer env AND /mnt/sysimage if mounted
+#   - fall back to /tmp/xibo-wifi-preseed stash if target not yet mounted
+#   - nmcli connection up so the installer has network for the rest
+#
+# Security: the _validate_nm_string function is copied VERBATIM from
+# kiosk/xibo-set-wifi.sh (authoritative source). Both paths must produce
+# byte-identical keyfiles for the same input — this will be enforced by
+# a bats test in #74. Any change to one MUST be mirrored in the other.
+#
+# Error handling: all failures are non-fatal (|| true). If whiptail /
+# nmcli aren't available in the %pre environment, or the user cancels,
+# we fall through to anaconda's own network phase (which is the status
+# quo). The worst case is "user sees anaconda's WiFi dialog" — never
+# "install aborted with no network".
+#
+# --- NOTE ---
+# Despite --erroronfail on the %pre, the block body wraps every step in
+# `|| true` so only a hard failure of the `cat /tmp/…` exit-hook aborts.
+# See the trailing `exit 0` below.
+%pre --erroronfail
+set +e
+LOG=/tmp/xibo-wifi-tui.log
+: > "$LOG"
+echo "xibo wifi-tui: $(date)" >> "$LOG"
+
+# Bail if whiptail or nmcli aren't available (older installer envs)
+if ! command -v whiptail >/dev/null 2>&1 || ! command -v nmcli >/dev/null 2>&1; then
+    echo "  whiptail or nmcli missing — skipping" >> "$LOG"
+    exit 0
+fi
+
+# Skip if wired is already up
+if nmcli -t -f TYPE,STATE dev status 2>/dev/null | grep -qE '^ethernet:connected'; then
+    echo "  wired connected — skipping" >> "$LOG"
+    exit 0
+fi
+
+# Skip if preseeded via kernel cmdline (#68 / Layer 2)
+if grep -qE 'xibo\.wifi_ssid=' /proc/cmdline; then
+    echo "  xibo.wifi_ssid= preseeded — skipping" >> "$LOG"
+    exit 0
+fi
+
+# Skip if no wireless hardware
+if ! nmcli -t -f DEVICE,TYPE dev status 2>/dev/null | grep -q ':wifi$'; then
+    echo "  no wireless hardware — skipping" >> "$LOG"
+    exit 0
+fi
+
+# --- Wait for NetworkManager readiness (up to 10s) --------------------
+nmcli radio wifi on 2>/dev/null || true
+for i in 1 2 3 4 5 6 7 8 9 10; do
+    state=$(nmcli -t -f STATE general status 2>/dev/null)
+    case "$state" in
+        connected|disconnected) break ;;
+    esac
+    sleep 1
+done
+echo "  nmcli state after wait: $state" >> "$LOG"
+
+whiptail --title "xiboplayer kiosk — Wi-Fi" --infobox "Scanning for Wi-Fi networks..." 8 50
+nmcli dev wifi rescan 2>/dev/null || true
+sleep 2
+
+# Build the whiptail menu options from nmcli output. Format:
+#   "SSID" "signal% security"
+# Dedupe by SSID (keep strongest), sort by signal desc, skip empties.
+MENU_OPTS=$(nmcli -t -f SSID,SIGNAL,SECURITY dev wifi list 2>/dev/null \
+    | awk -F: 'NF>=3 && $1!="" { if (!seen[$1] || $2 > seen[$1]) { seen[$1]=$2; sec[$1]=$3 } }
+               END { for (s in seen) printf "%s|%s|%s\n", s, seen[s], sec[s] }' \
+    | sort -t'|' -k2,2nr)
+
+if [ -z "$MENU_OPTS" ]; then
+    whiptail --title "xiboplayer kiosk — Wi-Fi" \
+        --msgbox "No Wi-Fi networks found.\n\nContinuing with anaconda's built-in network phase." 10 60
+    exit 0
+fi
+
+# Convert to whiptail --menu tag/item pairs
+WHIPTAIL_ARGS=""
+while IFS='|' read -r ssid signal security; do
+    [ -z "$ssid" ] && continue
+    # Sanity-cap signal to reasonable bounds for display
+    [ "$signal" -gt 100 ] 2>/dev/null && signal=100
+    label="${signal}%% ${security:-open}"
+    WHIPTAIL_ARGS="$WHIPTAIL_ARGS \"$ssid\" \"$label\""
+done <<< "$MENU_OPTS"
+
+# Also offer hidden network + skip rows as synthetic options
+WHIPTAIL_ARGS="$WHIPTAIL_ARGS \"(hidden)\" \"Enter SSID manually\""
+WHIPTAIL_ARGS="$WHIPTAIL_ARGS \"(skip)\"   \"Use wired / configure later\""
+
+# Use eval to expand the quoted pairs into whiptail's argv
+SSID=$(eval "whiptail --title 'xiboplayer kiosk — Wi-Fi' \
+    --menu 'Select a Wi-Fi network:' 20 70 12 $WHIPTAIL_ARGS" \
+    3>&1 1>&2 2>&3) || exit 0
+
+if [ "$SSID" = "(skip)" ] || [ -z "$SSID" ]; then
+    echo "  user skipped" >> "$LOG"
+    exit 0
+fi
+
+if [ "$SSID" = "(hidden)" ]; then
+    SSID=$(whiptail --title "xiboplayer kiosk — Hidden SSID" \
+        --inputbox "Enter the hidden network SSID:" 10 60 \
+        3>&1 1>&2 2>&3) || exit 0
+    [ -z "$SSID" ] && exit 0
+    SECURITY="WPA2"  # assume secured for hidden networks
+else
+    # Extract security for the chosen SSID from the menu data
+    SECURITY=$(printf '%s\n' "$MENU_OPTS" | awk -F'|' -v ssid="$SSID" '$1==ssid {print $3; exit}')
+fi
+
+# Ask for password if secured
+PSK=""
+if [ -n "$SECURITY" ] && [ "$SECURITY" != "--" ] && [ "$SECURITY" != "open" ]; then
+    PSK=$(whiptail --title "xiboplayer kiosk — Wi-Fi password" \
+        --passwordbox "Enter password for \"$SSID\":" 10 60 \
+        3>&1 1>&2 2>&3) || exit 0
+fi
+
+# --- Input validation (verbatim from kiosk/xibo-set-wifi.sh) -----------
+# ⚠ SYNC: kiosk/xibo-set-wifi.sh is the authoritative source. If you
+# change _validate_nm_string there, mirror the change here.
+_validate_nm_string() {
+    local label="$1" value="$2"
+    if printf '%s' "$value" | grep -qE $'[\x00-\x1f]'; then
+        echo "$label contains control characters — rejected" >&2
+        return 2
+    fi
+    if printf '%s' "$value" | grep -qE '^\[|\[(connection|wifi|wifi-security|ipv4|ipv6)\]'; then
+        echo "$label contains an NM INI section header — rejected" >&2
+        return 2
+    fi
+    return 0
+}
+
+if ! _validate_nm_string "SSID" "$SSID"; then
+    whiptail --title "xiboplayer kiosk — Invalid SSID" \
+        --msgbox "The SSID contains characters that are not allowed. Skipping Wi-Fi." 10 60
+    exit 0
+fi
+if [ -n "$PSK" ] && ! _validate_nm_string "PSK" "$PSK"; then
+    whiptail --title "xiboplayer kiosk — Invalid password" \
+        --msgbox "The password contains characters that are not allowed. Skipping Wi-Fi." 10 60
+    exit 0
+fi
+
+# --- Write NM keyfile (also from kiosk/xibo-set-wifi.sh, simplified) ---
+SAFE_NAME=$(printf '%s' "$SSID" | tr -c '[:alnum:]._-' '_')
+UUID=$(cat /proc/sys/kernel/random/uuid)
+KEYMGMT="wpa-psk"
+[ -z "$PSK" ] && KEYMGMT="none"
+
+write_keyfile_at() {
+    local dir="$1"
+    mkdir -p "$dir"
+    umask 077
+    if [ "$KEYMGMT" = "none" ]; then
+        cat > "$dir/${SAFE_NAME}.nmconnection" << INIEOF
+[connection]
+id=$SSID
+uuid=$UUID
+type=wifi
+autoconnect=true
+
+[wifi]
+mode=infrastructure
+ssid=$SSID
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=ignore
+INIEOF
+    else
+        cat > "$dir/${SAFE_NAME}.nmconnection" << INIEOF
+[connection]
+id=$SSID
+uuid=$UUID
+type=wifi
+autoconnect=true
+
+[wifi]
+mode=infrastructure
+ssid=$SSID
+
+[wifi-security]
+key-mgmt=$KEYMGMT
+psk=$PSK
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=ignore
+INIEOF
+    fi
+    chmod 600 "$dir/${SAFE_NAME}.nmconnection"
+    chown root:root "$dir/${SAFE_NAME}.nmconnection" 2>/dev/null || true
+}
+
+# Layer 1: installer environment NM (active right now in %pre)
+write_keyfile_at "/etc/NetworkManager/system-connections"
+
+# Layer 2: if /mnt/sysimage is already mounted by anaconda, write there too
+#          so the keyfile survives into the installed system
+if [ -d "/mnt/sysimage/etc/NetworkManager" ]; then
+    write_keyfile_at "/mnt/sysimage/etc/NetworkManager/system-connections"
+    echo "  wrote keyfile to /mnt/sysimage (target already mounted)" >> "$LOG"
+else
+    # Stash for %post to re-apply once /mnt/sysimage is available.
+    # SSID/PSK in /tmp is acceptable — the file is mode 0600 and %post
+    # will wipe it after processing.
+    umask 077
+    cat > /tmp/xibo-wifi-preseed << STASHEOF
+SSID=$SSID
+PSK=$PSK
+KEYMGMT=$KEYMGMT
+STASHEOF
+    chmod 600 /tmp/xibo-wifi-preseed
+    echo "  stashed to /tmp/xibo-wifi-preseed (target not yet mounted)" >> "$LOG"
+fi
+
+# Activate in the installer env so anaconda has network for %packages
+nmcli connection reload 2>/dev/null || true
+nmcli connection up "$SSID" 2>/dev/null || true
+
+whiptail --title "xiboplayer kiosk — Wi-Fi" --infobox "Connected to $SSID. Proceeding with install..." 8 60
+sleep 2
+
+exit 0
 %end
 
 # Auto-detect install disk — "best available" heuristic.

--- a/rpm/xiboplayer-kiosk.spec
+++ b/rpm/xiboplayer-kiosk.spec
@@ -1,5 +1,5 @@
 Name:           xiboplayer-kiosk
-Version:        0.4.25
+Version:        0.4.26
 Release:        1%{?dist}
 Summary:        Kiosk session scripts for Xibo digital signage players
 
@@ -136,6 +136,35 @@ install -m755 kiosk/gnome-kiosk-script.sh %{buildroot}%{_sysconfdir}/skel/.local
 /usr/bin/dconf update &>/dev/null || :
 
 %changelog
+* Sat Apr 11 2026 Pau Aliagas <linuxnow@gmail.com> - 0.4.26-1
+- Pre-anaconda whiptail Wi-Fi TUI (#72). New %pre --erroronfail block at
+  the top of kickstart/xiboplayer-kiosk.ks that runs BEFORE anaconda's
+  network phase. The whiptail picker only appears when (a) no wired link
+  is up AND (b) xibo.wifi_ssid= wasn't preseeded AND (c) wireless
+  hardware exists — otherwise it falls through silently. Closes the
+  "netinstall on a WiFi-only machine shows anaconda's complex GTK
+  dialog" gap that 0x0 flagged in horizon2026-2.
+- Security: the _validate_nm_string input validator is copied verbatim
+  from kiosk/xibo-set-wifi.sh (authoritative source). Both paths must
+  produce byte-identical NM keyfiles for the same input — this will be
+  enforced by a bats test in #74. Rejects control characters and NM
+  INI section headers inside SSID/PSK.
+- NM keyfile is written to /etc/NetworkManager/system-connections/
+  in the installer env AND (if /mnt/sysimage is already mounted) into
+  the target system. If /mnt/sysimage isn't mounted yet, credentials
+  are stashed to /tmp/xibo-wifi-preseed (mode 0600) and re-applied in
+  %post after the target filesystem is in place. The stash is shredded
+  after use.
+- Offline-first: no network dependency for the TUI itself — everything
+  runs from the installer env's built-in whiptail + nmcli. iPXE and
+  netinstall boots both work.
+- Hidden-SSID support via a synthetic "(hidden)" menu row that opens
+  an inputbox for the SSID. WPA2 is assumed.
+- Error handling: every step wraps in || true / return 0, so the TUI
+  can never abort the install. Worst case: user falls through to
+  anaconda's own WiFi dialog.
+- Closes #72
+
 * Sat Apr 11 2026 Pau Aliagas <linuxnow@gmail.com> - 0.4.25-1
 - Drop arexibo from the default image (#71). Arexibo is now a netinstall
   opt-in only: the kickstart %post pulls the arexibo package on demand


### PR DESCRIPTION
## Summary

Closes the "user boots netinstall ISO on a WiFi-only machine and hits anaconda's complex GTK dialog" gap flagged by 0x0 in horizon2026-2. Bumps version to **0.4.26**.

New `%pre --erroronfail` block at the top of the kickstart runs BEFORE anaconda's network phase with a simple whiptail picker.

## Entry conditions (all three must hold — else exit 0 silently)

1. No wired ethernet link up
2. `xibo.wifi_ssid=` NOT preseeded via kernel cmdline
3. Wireless hardware present

## Flow

1. Wait up to 10s for NetworkManager readiness (handles initrd race conditions)
2. `nmcli dev wifi rescan` + 2s sleep
3. Build whiptail menu from `nmcli dev wifi list` (dedupe by SSID, sort by signal)
4. Synthetic "(hidden)" row + "(skip)" row
5. whiptail passwordbox if secured
6. Validate SSID+PSK via **verbatim copy** of `_validate_nm_string` from `kiosk/xibo-set-wifi.sh`
7. Write NM keyfile to installer env AND `/mnt/sysimage` if mounted
8. Otherwise stash to `/tmp/xibo-wifi-preseed` (mode 0600) for `%post` to apply
9. `nmcli connection up` — installer has network for `%packages`
10. Show success infobox, exit 0

## Security

- `_validate_nm_string` verbatim from `xibo-set-wifi.sh` — #74 bats test will enforce identity
- PSK never on `/proc/<pid>/cmdline`
- Stash file is 0600 and `shred -u`'d after `%post` consumes it
- Every step wraps in `|| true` / `return 0` — **the TUI can NEVER abort an install**

## Design decision: inline rather than separate file

The plan originally called for `kickstart/xibo-wifi-tui.sh` as a separate file. Rejected because kickstart has no offline file-include mechanism — either `curl` (fails offline, which is the exact case we're fixing) or heredoc (duplication). Inlining keeps a single source of truth with the sync requirement flagged in the comment header.

## Test plan

- [x] `bash -n` on extracted `%pre` blocks passes
- [x] `bash -n` on extracted `%post` blocks passes
- [x] `%pre`/`%post`/`%end` blocks balanced (16 opens, 16 ends)
- [ ] CI: CodeQL + Analyze passes
- [ ] Manual: boot netinstall ISO on wired VM → TUI does NOT appear, install completes
- [ ] Manual: boot netinstall ISO on wireless VM with USB WiFi dongle → TUI appears, pick network, install completes with WiFi connected
- [ ] Manual: boot with `xibo.wifi_ssid=X xibo.wifi_psk=Y` appended → TUI does NOT appear (preseeded path wins)
- [ ] Manual: cancel the menu → install falls through to anaconda's own network phase

Closes #72