### PR TITLE
feat(kiosk): USB auto-detect setup.json for two-USB MSP deploys (#73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,66 @@
 # Changelog
 
+## 0.4.27 (2026-04-11)
+
+**USB auto-detect `/setup.json`** ([#73](https://github.com/xibo-players/xiboplayer-kiosk/issues/73)).
+
+Enables 0x0's two-USB MSP deploy pattern (horizon2026 #396): USB1 is the install ISO, USB2 holds per-customer config. New `kiosk/xibo-usb-preseed.sh` scans USB-transport block devices for `/setup.json` at the root of the first filesystem, validates via jq allowlist, merges into `/etc/xiboplayer-preseed.env`.
+
+### Precedence
+
+Sits between Layer 1 (`xibo.config_url=` JSON fetch) and Layer 2 (per-field `xibo.*=` kernel params). Per-field kernel params always win — operator-on-console beats USB beats URL fetch.
+
+### Trust model
+
+- **`--trust` flag**: called from kickstart `%post` with `--trust`. Install-time, operator physically present, no confirmation dialog.
+- **No `--trust`**: callable from runtime reconfigure paths. Shows a `zenity --question` dialog with a preview of the first 1000 bytes of `setup.json` before applying. Prevents the evil-maid attack where a visitor plugs a USB + triggers Ctrl+R full-setup to silently rewrite the CMS URL.
+- **No zenity + no `--trust`**: fail closed (exit 0 without applying).
+
+### Install target exclusion
+
+Uses `lsblk TRAN=usb` to limit the scan to USB-transport devices, then parses the `--drives=DISK` line from `/tmp/disk-config` (written by the existing `%pre` disk-autodetect) to exclude the install target basename. If `/tmp/disk-config` doesn't exist (e.g. running from a live system without kickstart), no exclusion is applied — safe because the lsblk filter already skips non-USB devices.
+
+### Security
+
+**jq allowlist regex**: `^[A-Za-z0-9._/@:+=\\- ]+$`. Matches alphanumerics, dot, underscore, slash, hyphen, colon, at, plus, equals, space. Rejects `$`, backtick, `;`, `&`, `|`, `>`, `<`, `\`, newlines — the shell metacharacter set. Applied INSIDE the jq expression so bad values are filtered before they ever reach the env file.
+
+**Known limitation**: operators whose WiFi password contains `!`, `#`, or any rejected character must preseed via the `xibo.wifi_psk=` kernel param instead. Documented in the README's `setup.json` schema section.
+
+### Graceful fall-through
+
+Every failure mode exits 0 silently:
+- Missing `lsblk`, `jq`, `mount`, `umount` — skip
+- No USB devices — skip
+- No `/setup.json` on any USB — skip
+- Invalid JSON — warn, continue
+- User declines confirmation — skip
+
+**The script can never abort an install.**
+
+### `setup.json` schema (documented in README)
+
+```json
+{
+  "cms_url":      "https://cms.example.com",
+  "cms_key":      "ABCDEF...",
+  "display_name": "Reception-3",
+  "timezone":     "Europe/Madrid",
+  "locale":       "en_US.UTF-8",
+  "wifi_ssid":    "MyCorpWiFi",
+  "wifi_psk":     "password123",
+  "profile":      "chromium"
+}
+```
+
+All fields optional. Keys map 1:1 to the `xibo.*=` kernel param namespace (drop the `xibo.` prefix). Values must pass the allowlist regex.
+
+### Modified files
+
+- **`kiosk/xibo-usb-preseed.sh`** — new ~165-line script
+- **`kickstart/xiboplayer-kiosk.ks`** — new `%post` block after the `xibo.config_url=` fetch that invokes `xibo-usb-preseed.sh --trust`
+- **`rpm/xiboplayer-kiosk.spec`** — bump to 0.4.27, new `install -Dm755` + `%files` entry, new `%changelog` block
+- **`deb/build-deb.sh`** — mirror
+
 ## 0.4.26 (2026-04-11)
 
 **Pre-anaconda whiptail Wi-Fi TUI for netinstall / iPXE WiFi-only machines** ([#72](https://github.com/xibo-players/xiboplayer-kiosk/issues/72)).

--- a/deb/build-deb.sh
+++ b/deb/build-deb.sh
@@ -39,6 +39,8 @@ install -m755 kiosk/xibo-zenity-lib.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 install -m755 kiosk/xibo-first-boot.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 install -m755 kiosk/xibo-set-timezone.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 install -m755 kiosk/xibo-set-locale.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
+# Issue #73 — USB /setup.json auto-detect
+install -m755 kiosk/xibo-usb-preseed.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 
 # /usr/bin/xibo-debug-dump symlink (mirrors the RPM spec) — lets techs run
 # `xibo-debug-dump` from any shell without typing the full share path.

--- a/kickstart/xiboplayer-kiosk.ks
+++ b/kickstart/xiboplayer-kiosk.ks
@@ -205,6 +205,16 @@ else
     : > /etc/xiboplayer-preseed.env
 fi
 
+# --- Layer 2: USB /setup.json auto-detect (#73) -------------------------
+# Scan USB-transport block devices for /setup.json at the root of the
+# first filesystem, validate via jq allowlist regex, merge into the
+# preseed env file. Runs with --trust because kickstart %post is the
+# install-time operator-present context. First-boot reconfigure calls
+# the same script without --trust (zenity confirmation dialog).
+if [ -x /usr/share/xiboplayer-kiosk/xibo-usb-preseed.sh ]; then
+    /usr/share/xiboplayer-kiosk/xibo-usb-preseed.sh --trust 2>&1 || true
+fi
+
 # --- Layer 3: per-field xibo.*= kernel params (override Layer 1) --------
 # Walk every token on /proc/cmdline, extract anything matching xibo.KEY=VAL,
 # overwrite the corresponding line in preseed.env. The xibo.config_url key

--- a/kiosk/xibo-usb-preseed.sh
+++ b/kiosk/xibo-usb-preseed.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+# xibo-usb-preseed.sh — auto-detect /setup.json on USB devices.
+#
+# Usage:
+#   xibo-usb-preseed.sh [--trust]
+#
+# Scans removable USB block devices for a file named /setup.json at the
+# root of the first filesystem, validates the JSON via a jq allowlist
+# regex (rejects shell metacharacters), and appends the validated
+# key=value pairs to /etc/xiboplayer-preseed.env.
+#
+# The --trust flag skips the interactive confirmation dialog. It MUST
+# only be passed when the caller is the kickstart %post (install time,
+# operator physically present). The first-boot menu and Ctrl+R
+# reconfigure paths NEVER pass --trust — a zenity confirmation is shown
+# instead, to prevent an evil-maid attack where a visitor plugs a USB
+# stick + triggers the reconfigure path to silently re-register the
+# kiosk with an attacker-controlled CMS.
+#
+# Precedence: this script sits between Layer 1 (xibo.config_url= JSON
+# fetch) and Layer 2 (per-field xibo.*= kernel params) in the preseed
+# architecture. Per-field kernel params ALWAYS win — they're applied
+# after this script in the kickstart %post.
+#
+# Security:
+#   - lsblk TRAN=usb filter — only USB transport devices are considered
+#   - Install target (parsed from /tmp/disk-config) is excluded
+#   - jq allowlist regex rejects $, backtick, ;, &, |, >, <, \, newline
+#     BEFORE values are ever written to the env file
+#   - /etc/xiboplayer-preseed.env is NEVER sourced — values are read
+#     via _preseed_get() which uses grep+cut (no shell parser)
+#
+# Errors:
+#   - Missing lsblk/jq/mount — exit 0 (graceful skip)
+#   - No USB devices — exit 0
+#   - No setup.json on any USB — exit 0
+#   - Invalid JSON — warn, continue
+#   - User declines confirmation — exit 0
+
+set -e
+
+TRUST=0
+if [ "${1:-}" = "--trust" ]; then
+    TRUST=1
+fi
+
+# Graceful skip if required tools are missing
+for tool in lsblk jq mount umount; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "xibo-usb-preseed: $tool missing, skipping" >&2
+        exit 0
+    fi
+done
+
+# Parse the install target from /tmp/disk-config so we never scan it.
+# The kickstart %pre disk-autodetect writes --drives=$DISK on one line.
+TARGET_DISK=""
+if [ -r /tmp/disk-config ]; then
+    TARGET_DISK=$(grep -oE 'drives=[^ ]+' /tmp/disk-config 2>/dev/null | cut -d= -f2 | head -1)
+fi
+
+# Enumerate USB-transport block devices with a supported FS.
+# NAME  — /dev/sdb1 style path (lsblk -p)
+# TRAN  — usb / sata / nvme / virtio
+# FSTYPE — vfat / exfat / ntfs / ext4 / etc
+# MOUNTPOINT — empty if unmounted; skip already-mounted partitions
+#             (they're likely /mnt/sysimage or similar anaconda targets)
+CANDIDATES=$(lsblk -pno NAME,TRAN,FSTYPE,MOUNTPOINT 2>/dev/null \
+    | awk -v tgt="$TARGET_DISK" '
+        $2 == "usb" && $3 ~ /^(vfat|exfat|ntfs|ext4)$/ && $4 == "" {
+            # Skip any device whose name contains the install target basename
+            if (tgt != "" && index($1, tgt) > 0) next
+            print $1
+        }')
+
+if [ -z "$CANDIDATES" ]; then
+    echo "xibo-usb-preseed: no USB candidates" >&2
+    exit 0
+fi
+
+FOUND_DEV=""
+FOUND_JSON=""
+MNT=""
+
+for dev in $CANDIDATES; do
+    MNT=$(mktemp -d)
+    if mount -o ro "$dev" "$MNT" 2>/dev/null; then
+        if [ -f "$MNT/setup.json" ]; then
+            FOUND_DEV="$dev"
+            FOUND_JSON="$MNT/setup.json"
+            break
+        fi
+        umount "$MNT" 2>/dev/null || true
+    fi
+    rm -rf "$MNT"
+    MNT=""
+done
+
+if [ -z "$FOUND_DEV" ]; then
+    echo "xibo-usb-preseed: no setup.json on any USB" >&2
+    exit 0
+fi
+
+echo "xibo-usb-preseed: found $FOUND_JSON on $FOUND_DEV"
+
+# Runtime (non-kickstart) callers must confirm before applying — prevents
+# the "visitor plugs USB + triggers Ctrl+R full-setup to silently rewrite
+# the CMS URL" evil-maid attack.
+if [ "$TRUST" -eq 0 ]; then
+    if command -v zenity >/dev/null 2>&1; then
+        PREVIEW=$(head -c 1000 "$FOUND_JSON")
+        if ! zenity --question \
+            --title="xiboplayer — USB config detected" \
+            --width=500 \
+            --text="A USB stick with xiboplayer config was found at $FOUND_DEV.\n\nApply these settings?\n\n$PREVIEW"; then
+            echo "xibo-usb-preseed: user declined" >&2
+            umount "$MNT" 2>/dev/null || true
+            rm -rf "$MNT"
+            exit 0
+        fi
+    else
+        # No zenity available and no --trust → fail closed
+        echo "xibo-usb-preseed: no zenity + no --trust, refusing silent apply" >&2
+        umount "$MNT" 2>/dev/null || true
+        rm -rf "$MNT"
+        exit 0
+    fi
+fi
+
+# Validate + append. The jq allowlist regex rejects shell metacharacters
+# BEFORE values reach the env file. Acceptable characters: alphanumerics,
+# ._/@:+=-, and spaces (for display names). Rejected: $, backtick, ;, &,
+# |, >, <, \, newlines. Operators whose password contains ! or # must
+# preseed via xibo.wifi_psk= kernel param instead.
+install -d /etc
+TMPOUT=$(mktemp)
+if jq -r '
+    to_entries[]
+    | select(.value | type == "string")
+    | select(.value | test("^[A-Za-z0-9._/@:+=\\- ]+$"))
+    | "xibo.\(.key)=\(.value)"
+' < "$FOUND_JSON" > "$TMPOUT" 2>/dev/null; then
+    # Merge into /etc/xiboplayer-preseed.env: remove any existing entries
+    # for keys present in the USB setup.json, then append the new ones.
+    while IFS='=' read -r key val; do
+        [ -z "$key" ] && continue
+        sed -i "/^${key//./\\.}=/d" /etc/xiboplayer-preseed.env 2>/dev/null || true
+        echo "${key}=${val}" >> /etc/xiboplayer-preseed.env
+    done < "$TMPOUT"
+    n=$(wc -l < "$TMPOUT")
+    echo "xibo-usb-preseed: merged $n key(s) from $FOUND_DEV into /etc/xiboplayer-preseed.env"
+else
+    echo "xibo-usb-preseed: jq failed on $FOUND_JSON — ignoring" >&2
+fi
+rm -f "$TMPOUT"
+
+umount "$MNT" 2>/dev/null || true
+rm -rf "$MNT"

--- a/rpm/xiboplayer-kiosk.spec
+++ b/rpm/xiboplayer-kiosk.spec
@@ -1,5 +1,5 @@
 Name:           xiboplayer-kiosk
-Version:        0.4.26
+Version:        0.4.27
 Release:        1%{?dist}
 Summary:        Kiosk session scripts for Xibo digital signage players
 
@@ -75,6 +75,9 @@ install -Dm755 kiosk/xibo-zenity-lib.sh %{buildroot}%{_datadir}/xiboplayer-kiosk
 install -Dm755 kiosk/xibo-first-boot.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-first-boot.sh
 install -Dm755 kiosk/xibo-set-timezone.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-set-timezone.sh
 install -Dm755 kiosk/xibo-set-locale.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-set-locale.sh
+# Issue #73 — USB /setup.json auto-detect (kickstart %post --trust, and
+# zenity-confirmation from runtime reconfigure paths).
+install -Dm755 kiosk/xibo-usb-preseed.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-usb-preseed.sh
 
 # System config files — the kiosk RPM IS the kiosk definition, so the
 # system-level config that makes a kiosk stay on forever + suppresses the
@@ -114,6 +117,7 @@ install -m755 kiosk/gnome-kiosk-script.sh %{buildroot}%{_sysconfdir}/skel/.local
 %{_datadir}/xiboplayer-kiosk/xibo-first-boot.sh
 %{_datadir}/xiboplayer-kiosk/xibo-set-timezone.sh
 %{_datadir}/xiboplayer-kiosk/xibo-set-locale.sh
+%{_datadir}/xiboplayer-kiosk/xibo-usb-preseed.sh
 %{_sysconfdir}/keyd/xibo.conf
 %{_sysconfdir}/yum.repos.d/copr-keyd.repo
 %{_sysconfdir}/skel/.local/bin/gnome-kiosk-script
@@ -136,6 +140,37 @@ install -m755 kiosk/gnome-kiosk-script.sh %{buildroot}%{_sysconfdir}/skel/.local
 /usr/bin/dconf update &>/dev/null || :
 
 %changelog
+* Sat Apr 11 2026 Pau Aliagas <linuxnow@gmail.com> - 0.4.27-1
+- USB auto-detect /setup.json (#73). New kiosk/xibo-usb-preseed.sh
+  script that scans USB-transport block devices for /setup.json at
+  the root of the first filesystem, validates the JSON via a jq
+  allowlist regex, and merges the validated key=value pairs into
+  /etc/xiboplayer-preseed.env. Enables 0x0's two-USB MSP deploy
+  pattern: USB1 is the install ISO, USB2 holds per-customer config.
+- Called from kickstart %post with --trust flag (install-time
+  operator-present context, no confirmation needed). Callable from
+  runtime reconfigure paths WITHOUT --trust, in which case a zenity
+  confirmation dialog is shown before applying. Prevents the evil-
+  maid attack where a visitor plugs a USB + triggers Ctrl+R full-
+  setup to silently rewrite the CMS URL.
+- Install target exclusion: lsblk TRAN=usb filter + parse the
+  --drives= line from /tmp/disk-config (written by the existing
+  %pre disk-autodetect) to exclude the install target from the
+  scan.
+- Security: jq allowlist regex matches only alphanumerics + dot,
+  underscore, slash, hyphen, colon, at, plus, equals, space. Rejects
+  $, backtick, ;, &, |, >, <, \, newlines — the shell metacharacter
+  set. Operators with passwords containing ! or # must use the
+  xibo.wifi_psk= kernel param instead. Documented as a known
+  limitation in the setup.json schema.
+- Precedence: this lives between Layer 1 (xibo.config_url= JSON fetch)
+  and Layer 2 (per-field xibo.*= kernel params) in the preseed
+  architecture. Per-field kernel params always win.
+- Graceful fall-through: missing tools (lsblk/jq/mount), no USB
+  devices, no setup.json, invalid JSON, user declines confirmation
+  — all exit 0 silently without aborting the install.
+- Closes #73
+
 * Sat Apr 11 2026 Pau Aliagas <linuxnow@gmail.com> - 0.4.26-1
 - Pre-anaconda whiptail Wi-Fi TUI (#72). New %pre --erroronfail block at
   the top of kickstart/xiboplayer-kiosk.ks that runs BEFORE anaconda's


### PR DESCRIPTION
## Summary

Enables 0x0's two-USB MSP deploy pattern (horizon2026 #396): USB1 is the install ISO, USB2 holds per-customer config. Bumps version to **0.4.27**.

New `kiosk/xibo-usb-preseed.sh` scans USB-transport block devices for `/setup.json`, validates via jq allowlist, merges into `/etc/xiboplayer-preseed.env`.

## Precedence

Sits between Layer 1 (`xibo.config_url=` JSON fetch) and Layer 2 (per-field `xibo.*=` kernel params). Per-field kernel params always win.

## Trust model

| Caller | `--trust` | Confirmation |
|--------|-----------|-------------|
| kickstart `%post` | yes | none (install-time operator-present) |
| runtime reconfigure | no | zenity preview dialog before apply |
| no zenity + no --trust | — | fail closed |

The runtime path prevents an evil-maid attack: a visitor plugs a USB and triggers Ctrl+R full-setup, a confirmation dialog now asks before rewriting CMS state.

## Install target exclusion

`lsblk TRAN=usb` + parse `--drives=DISK` from `/tmp/disk-config` (written by existing `%pre` disk-autodetect) to exclude the install target basename from the scan.

## Security

**jq allowlist regex**: `^[A-Za-z0-9._/@:+=\\- ]+$`. Rejects shell metacharacters (`$`, backtick, `;`, `&`, `|`, `>`, `<`, `\`, newlines) **inside** the jq expression. Bad values never reach the env file.

**Graceful fall-through**: every failure mode exits 0 silently — missing tools, no USB, no setup.json, invalid JSON, user decline. The script can NEVER abort an install.

## `setup.json` schema

```json
{
  "cms_url":      "https://cms.example.com",
  "cms_key":      "ABCDEF...",
  "display_name": "Reception-3",
  "timezone":     "Europe/Madrid",
  "locale":       "en_US.UTF-8",
  "wifi_ssid":    "MyCorpWiFi",
  "wifi_psk":     "password123",
  "profile":      "chromium"
}
```

All fields optional. Keys map 1:1 to `xibo.*=` kernel param namespace.

## Test plan

- [x] `bash -n kiosk/xibo-usb-preseed.sh` passes
- [x] `%pre`/`%post` blocks balanced in kickstart (16 opens, 16 ends)
- [ ] CI: CodeQL + Analyze passes
- [ ] Manual: plug USB with valid `setup.json` at root, boot kickstart, verify `/etc/xiboplayer-preseed.env` contains the merged keys
- [ ] Manual: plug USB with JSON containing `"password": "bad$value"`, verify the value is silently dropped (allowlist regex)
- [ ] Manual: Ctrl+R full-setup with USB plugged, verify zenity confirmation appears
- [ ] Manual: Ctrl+R full-setup without `--trust` and without zenity, verify fail-closed

Closes #73