### PR TITLE
fix(atomic): emit version output + drop arexibo from release notes

### DIFF
--- a/.github/workflows/atomic.yml
+++ b/.github/workflows/atomic.yml
@@ -244,10 +244,22 @@ jobs:
       - name: Determine version
         id: version
         run: |
+          # IMPORTANT: emit BOTH `tag` (used as the R2 path prefix) AND
+          # `version` (used as the ISO-filename infix). For a tag push,
+          # strip the leading "v" so the filename uses plain semver
+          # (matches the build-iso-{x86_64,aarch64} jobs above which
+          # already produce xiboplayer-kiosk-atomic_${VERSION}_{arch}.iso
+          # with VERSION being the stripped value). The release-notes
+          # step at the bottom of this file consumes `version` for the
+          # download URLs — if it's empty, URLs get a double underscore
+          # and 404 (issue flagged after v0.4.29 release).
           if [[ "${{ github.ref_type }}" == "tag" ]]; then
             echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=atomic-$(date +%Y%m%d)" >> "$GITHUB_OUTPUT"
+            DATE=$(date +%Y%m%d)
+            echo "tag=atomic-${DATE}" >> "$GITHUB_OUTPUT"
+            echo "version=${DATE}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Download all artifacts
@@ -317,7 +329,7 @@ jobs:
 
           - **Fedora bootc 43** (immutable, container-native updates)
           - **Full codecs**: ffmpeg, gstreamer, VA-API
-          - **Players**: xiboplayer-electron, xiboplayer-chromium, arexibo
+          - **Players**: xiboplayer-electron, xiboplayer-chromium (arexibo available via netinstall — pass \`xibo.profile=arexibo\` on the kernel cmdline)
           - **Multimedia**: VLC, mpv, GNOME Showtime
           - **Kiosk session**: GDM autologin → gnome-kiosk
 


### PR DESCRIPTION
## Summary

Two related fixes in \`.github/workflows/atomic.yml\`:

### 1. Empty \`\${VERSION}\` in release body → 404 URLs

The \"Determine version\" step was only emitting \`tag\`, not \`version\`. The release-notes step consumes \`steps.version.outputs.version\` for the download URLs (\`.../xiboplayer-kiosk-atomic_\${VERSION}_{arch}.iso\`), so \`VERSION\` was empty — producing URLs with a double underscore (\`xiboplayer-kiosk-atomic__x86_64.iso\`) that 404.

**The actual ISO files are uploaded with the correct filename** (the x86_64 + aarch64 build jobs use their own version expression earlier in the workflow, which works). Only the release body text is wrong.

Fix: emit both \`tag\` and \`version\` from the same step:
- Tag push (\`v0.4.29\`) → \`tag=v0.4.29\`, \`version=0.4.29\`
- Nightly (no tag) → \`tag=atomic-20260411\`, \`version=20260411\`

The **already-published** v0.4.29 release body was patched in place via \`gh release edit\`. All three URLs (x86_64, aarch64, SHA256SUMS) now return HTTP 200.

### 2. Stale \"arexibo\" in Players list

The release body still listed arexibo as a bundled player. #71 dropped it from the default image in 0.4.25. Updated to note arexibo is available via netinstall with \`xibo.profile=arexibo\` on the kernel cmdline.

## Test plan

- [x] Verified v0.4.29 atomic URLs all return 200 after \`gh release edit\`
- [ ] CI passes
- [ ] Next tag push generates a correctly-formatted release body automatically (no more manual \`gh release edit\`)