### PR TITLE
fix(kickstart): set xibo Session= to gnome-kiosk-script-wayland (#91)

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-iso.yml@14aa734  # main @ 2026-04-11 (adds iso-volid / iso-cmdline-* / iso-grub-replacements / skip-preflight / upload-as-artifact inputs — companion to #89)
+    uses: xibo-players/.github/.github/workflows/build-iso.yml@14aa7341746be1d28be70f8aee6ea33f2e190925  # main @ 2026-04-11 (adds iso-volid / iso-cmdline-* / iso-grub-replacements / skip-preflight / upload-as-artifact inputs — companion to #89)
     with:
       package-name: xiboplayer-kiosk
       kickstart-file: 'kickstart/xiboplayer-kiosk.ks'

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-iso.yml@14aa7341746be1d28be70f8aee6ea33f2e190925  # main @ 2026-04-11 (adds iso-volid / iso-cmdline-* / iso-grub-replacements / skip-preflight / upload-as-artifact inputs — companion to #89)
+    uses: xibo-players/.github/.github/workflows/build-iso.yml@bd8bb5b8c550210652a6aa1a7915df68b606a916  # main @ 2026-04-11 (iso-* customization inputs + R2 test prefix for fast test downloads — companion to #89)
     with:
       package-name: xiboplayer-kiosk
       kickstart-file: 'kickstart/xiboplayer-kiosk.ks'

--- a/.github/workflows/test-image.yml
+++ b/.github/workflows/test-image.yml
@@ -52,7 +52,7 @@ concurrency:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-iso.yml@14aa734
+    uses: xibo-players/.github/.github/workflows/build-iso.yml@14aa7341746be1d28be70f8aee6ea33f2e190925  # docs(build-iso): document customization + test-build inputs (#90 companion)
     with:
       package-name: xiboplayer-kiosk
       kickstart-file: 'kickstart/xiboplayer-kiosk.ks'

--- a/.github/workflows/test-image.yml
+++ b/.github/workflows/test-image.yml
@@ -52,7 +52,7 @@ concurrency:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-iso.yml@14aa7341746be1d28be70f8aee6ea33f2e190925  # docs(build-iso): document customization + test-build inputs (#90 companion)
+    uses: xibo-players/.github/.github/workflows/build-iso.yml@bd8bb5b8c550210652a6aa1a7915df68b606a916  # feat(build-iso): test builds also upload to R2 test prefix (#89 follow-up — fast download)
     with:
       package-name: xiboplayer-kiosk
       kickstart-file: 'kickstart/xiboplayer-kiosk.ks'

--- a/kickstart/xiboplayer-kiosk.ks
+++ b/kickstart/xiboplayer-kiosk.ks
@@ -371,13 +371,36 @@ AutomaticLogin=xibo
 EOF
 %end
 
-# Configure AccountsService — default GNOME session for first boot
-# The setup wizard will switch to gnome-kiosk-script-wayland after configuration
+# Configure AccountsService — default session for the xibo user.
+#
+# Sets the xibo user's GDM session DIRECTLY to gnome-kiosk-script-wayland
+# (the gnome-kiosk-script-session package provides
+# /usr/share/wayland-sessions/gnome-kiosk-script-wayland.desktop). On
+# first boot, GDM auto-login lands directly inside
+# kiosk/gnome-kiosk-script.xibo.sh — no intermediate vanilla-GNOME
+# session, no session switch mid-flight.
+#
+# History: before #71 (commit 12b003c, 0.4.25) this was `Session=gnome`
+# because the libadwaita Python wizard (xiboplayer-setup.py) was
+# expected to autostart in vanilla GNOME on first boot, fill in the CMS
+# config, then switch AccountsService to gnome-kiosk-script-wayland via
+# doas and log out. #71 deleted the Python wizard (0x0 rejected the
+# libadwaita approach in S6 #313-378) and was supposed to also flip
+# this Session= line, but that edit was forgotten — which stranded
+# every 0.4.25+ install in vanilla GNOME forever. Fixed in #91.
+#
+# The zenity first-boot menu (#67) now runs INSIDE the kiosk session
+# via kiosk/gnome-kiosk-script.xibo.sh, gated by the
+# ~/.local/share/xibo/first-boot-done sentinel. No separate
+# "wizard session → kiosk session" switch is needed.
+#
+# Mirrored at mkosi-extra/var/lib/AccountsService/users/xibo for the
+# mkosi + atomic/bootc build paths.
 %post --erroronfail
 mkdir -p /var/lib/AccountsService/users
 cat > /var/lib/AccountsService/users/xibo << 'EOF'
 [User]
-Session=gnome
+Session=gnome-kiosk-script-wayland
 SystemAccount=false
 EOF
 %end

--- a/mkosi-extra/var/lib/AccountsService/users/xibo
+++ b/mkosi-extra/var/lib/AccountsService/users/xibo
@@ -1,3 +1,3 @@
 [User]
-Session=gnome
+Session=gnome-kiosk-script-wayland
 SystemAccount=false

--- a/tests/unit/preseed-extractor.bats
+++ b/tests/unit/preseed-extractor.bats
@@ -60,3 +60,25 @@ KS="$REPO_ROOT/kickstart/xiboplayer-kiosk.ks"
     ! grep -v '^#' "$KS" | grep -q 'xiboplayer-setup\.desktop'
     ! grep -v '^#' "$KS" | grep -q 'xiboplayer-setup\.py'
 }
+
+@test "AccountsService: xibo user defaults to the kiosk session, not vanilla GNOME" {
+    # Regression guard for #91 — 0.4.25 through 0.4.29 shipped with
+    # Session=gnome in both the kickstart and mkosi-extra AccountsService
+    # config files, which stranded every install in vanilla GNOME instead
+    # of gnome-kiosk-script-wayland. Reason: #71 deleted the Python wizard
+    # that was supposed to flip Session= at first boot but forgot to also
+    # flip this default.
+    #
+    # Both files MUST set Session=gnome-kiosk-script-wayland and MUST NOT
+    # have a bare `Session=gnome` line anywhere.
+
+    # Kickstart %post heredoc
+    grep -q '^Session=gnome-kiosk-script-wayland' "$KS"
+    ! grep -qE '^Session=gnome$' "$KS"
+
+    # mkosi-extra overlay (mkosi + atomic/bootc build paths)
+    local MKOSI_FILE="$REPO_ROOT/mkosi-extra/var/lib/AccountsService/users/xibo"
+    [ -f "$MKOSI_FILE" ]
+    grep -q '^Session=gnome-kiosk-script-wayland$' "$MKOSI_FILE"
+    ! grep -qE '^Session=gnome$' "$MKOSI_FILE"
+}


### PR DESCRIPTION
Closes #91.

## The regression

v0.4.25 through v0.4.29 shipped with \`Session=gnome\` in the xibo user's AccountsService config. Every installed kiosk boots into a full vanilla Fedora GNOME desktop instead of \`gnome-kiosk-script-wayland\`. Nothing in the current flow switches back — the libadwaita Python wizard that used to do it was deleted in #71 but the \`Session=\` default was never flipped.

0x0 confirmed the symptom in S6 community posts after downloading 0.4.29; reproduced locally in the netinstall test earlier today.

## Fix

Two lines + a rewritten comment + a bats guard:

1. \`kickstart/xiboplayer-kiosk.ks:380\` — \`Session=gnome\` → \`Session=gnome-kiosk-script-wayland\`
2. \`mkosi-extra/var/lib/AccountsService/users/xibo:2\` — same (mkosi + atomic/bootc path)
3. Obsolete comment above the kickstart block rewritten to document the new direct-to-kiosk design
4. **New bats regression guard** in \`tests/unit/preseed-extractor.bats\` asserting BOTH files have \`Session=gnome-kiosk-script-wayland\` and NOT bare \`Session=gnome\`

## Verification via test-image.yml (#90)

Branch name \`fix/0.4.30-session-regression-91\` matches the \`fix/**\` auto-trigger pattern, so pushing this PR fires \`test-image.yml\` automatically. Will download the resulting artifact, boot in qemu, and confirm:

- [ ] GDM auto-login lands directly in the kiosk session (no vanilla GNOME flash)
- [ ] No Welcome / desktop preview screens
- [ ] Zenity first-boot menu appears
- [ ] Player service starts after menu completes

## Scope

**This PR fixes ONLY the Session= regression.** Other cleanups from the current working tree are split into their own PRs per semantic-commits policy:

- #92 — add \`gnome-terminal\` back to \`%packages\` for operator debugging
- #93 — remove \`gnome-initial-setup\` package entirely
- #94 — suppress GNOME workspace overview (\`wm.preferences theme 'Adwaita'\`)
- #95 — Chromium managed policies (disable Save Password / autofill / translate / signin)

(Issues #92-#95 will be created as I open those PRs.)

## Production CI impact

None. This PR only touches two config files, the comment block, and a bats assertion. Tagging a new version would still rebuild all production variants normally.