### PR TITLE
fix(show-cms): enlarge Ctrl+R reconfigure menu so 3rd row is visible (#95)

### DIFF
--- a/kiosk/xibo-show-cms.sh
+++ b/kiosk/xibo-show-cms.sh
@@ -33,7 +33,7 @@ ACTION=$(zenity --list --title="xiboplayer" \
     "reconfigure" "Reset player config and restart" \
     "full-setup" "Return to first-boot wizard (WiFi, timezone, etc.)" \
     "cancel" "Do nothing" \
-    --width=350 --height=280 2>/dev/null)
+    --width=500 --height=420 2>/dev/null)
 
 case "$ACTION" in
     reconfigure)


### PR DESCRIPTION
Closes #95. One-line dimensional fix for the zenity --list at kiosk/xibo-show-cms.sh:30 — bumps --width=350 --height=280 → --width=500 --height=420 so all 3 action rows fit without clipping.

Test build auto-triggers on push (fix/** pattern from #89).