### PR TITLE
feat(atomic): version-pinnable GHCR tags for bootc container

### DIFF
--- a/.github/workflows/atomic.yml
+++ b/.github/workflows/atomic.yml
@@ -40,11 +40,21 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image
+        env:
+          # On tag pushes (v0.4.35), also tag with the kiosk version so
+          # operators can pin: `bootc switch :v0.4.35`. On branch / schedule
+          # / dispatch builds, VERSION is empty and no version tag is added.
+          VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
         run: |
+          IMG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
           podman build \
-            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.FEDORA_VERSION }}-x86_64 \
+            --tag "${IMG}:${{ env.FEDORA_VERSION }}-x86_64" \
+            ${VERSION:+--tag "${IMG}:${VERSION}-x86_64"} \
             -f atomic/Containerfile .
-          podman push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.FEDORA_VERSION }}-x86_64
+          podman push "${IMG}:${{ env.FEDORA_VERSION }}-x86_64"
+          if [ -n "$VERSION" ]; then
+            podman push "${IMG}:${VERSION}-x86_64"
+          fi
 
   build-oci-aarch64:
     name: Build OCI Image (aarch64)
@@ -62,11 +72,18 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image
+        env:
+          VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
         run: |
+          IMG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
           podman build \
-            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.FEDORA_VERSION }}-aarch64 \
+            --tag "${IMG}:${{ env.FEDORA_VERSION }}-aarch64" \
+            ${VERSION:+--tag "${IMG}:${VERSION}-aarch64"} \
             -f atomic/Containerfile .
-          podman push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.FEDORA_VERSION }}-aarch64
+          podman push "${IMG}:${{ env.FEDORA_VERSION }}-aarch64"
+          if [ -n "$VERSION" ]; then
+            podman push "${IMG}:${VERSION}-aarch64"
+          fi
 
   push-manifest:
     name: Push multi-arch manifest
@@ -83,17 +100,29 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create and push manifest
+        env:
+          VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
         run: |
-          podman manifest create ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.FEDORA_VERSION }} \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.FEDORA_VERSION }}-x86_64 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.FEDORA_VERSION }}-aarch64
-          podman manifest create ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.FEDORA_VERSION }}-x86_64 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.FEDORA_VERSION }}-aarch64
-          podman manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.FEDORA_VERSION }} \
-            docker://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.FEDORA_VERSION }}
-          podman manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
-            docker://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          IMG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          FV="${{ env.FEDORA_VERSION }}"
+
+          # Fedora-version manifest (always)
+          podman manifest create "${IMG}:${FV}" \
+            "${IMG}:${FV}-x86_64" "${IMG}:${FV}-aarch64"
+          podman manifest push "${IMG}:${FV}" "docker://${IMG}:${FV}"
+
+          # latest manifest (always)
+          podman manifest create "${IMG}:latest" \
+            "${IMG}:${FV}-x86_64" "${IMG}:${FV}-aarch64"
+          podman manifest push "${IMG}:latest" "docker://${IMG}:latest"
+
+          # Kiosk-version manifest (tag pushes only, e.g. v0.4.35)
+          if [ -n "$VERSION" ]; then
+            podman manifest create "${IMG}:${VERSION}" \
+              "${IMG}:${VERSION}-x86_64" "${IMG}:${VERSION}-aarch64"
+            podman manifest push "${IMG}:${VERSION}" "docker://${IMG}:${VERSION}"
+            echo "Pushed version manifest: ${IMG}:${VERSION}"
+          fi
 
   build-iso-x86_64:
     name: Build ISO (x86_64)

--- a/workers/latest-redirect/package.json
+++ b/workers/latest-redirect/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "xiboplayer-kiosk-latest-redirect",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev"
+  },
+  "devDependencies": {
+    "wrangler": "^4"
+  }
+}

--- a/workers/latest-redirect/src/index.js
+++ b/workers/latest-redirect/src/index.js
@@ -1,0 +1,103 @@
+/**
+ * Cloudflare Worker: latest-redirect
+ *
+ * Intercepts requests to /xiboplayer-kiosk/latest/<filename> and
+ * returns a 302 redirect to the versioned path, reading the current
+ * version from the LATEST file in the R2 bucket.
+ *
+ * Zero R2 storage overhead — no file duplication, just a redirect.
+ * The LATEST file is already written by build-iso.yml on every
+ * release tag push.
+ *
+ * URL transformation:
+ *   /xiboplayer-kiosk/latest/xiboplayer-kiosk-netinstall_x86_64.iso
+ *   → 302 → /xiboplayer-kiosk/0.4.35/xiboplayer-kiosk-netinstall_0.4.35_x86_64.iso
+ *
+ * The version string is injected before the architecture suffix
+ * (_x86_64 or _aarch64) in the filename. Files without an arch
+ * suffix (e.g. SHA256SUMS) redirect as-is.
+ *
+ * Caching: the LATEST file read is cached in-memory for 60s so
+ * concurrent requests don't each hit R2. At 302-redirect time,
+ * Cloudflare's CDN cache handles the actual file delivery with
+ * its normal cache rules.
+ */
+
+// In-memory cache for the LATEST version string. Avoids hitting R2
+// on every request. Workers have ~128 MB memory and persist across
+// requests within the same isolate (~30s–5min lifetime).
+let cachedVersion = null;
+let cachedAt = 0;
+const CACHE_TTL_MS = 60_000; // 60 seconds
+
+/**
+ * Read the current version from the LATEST file in the R2 bucket.
+ * Returns the trimmed version string (e.g. "0.4.35") or null.
+ */
+async function getLatestVersion(bucket) {
+  const now = Date.now();
+  if (cachedVersion && (now - cachedAt) < CACHE_TTL_MS) {
+    return cachedVersion;
+  }
+
+  const obj = await bucket.get('xiboplayer-kiosk/LATEST');
+  if (!obj) return null;
+
+  cachedVersion = (await obj.text()).trim();
+  cachedAt = now;
+  return cachedVersion;
+}
+
+/**
+ * Transform a version-less filename into a versioned one.
+ *
+ * Input:  "xiboplayer-kiosk-netinstall_x86_64.iso", version "0.4.35"
+ * Output: "xiboplayer-kiosk-netinstall_0.4.35_x86_64.iso"
+ *
+ * Pattern: insert _<version> before _(x86_64|aarch64).
+ * If no arch suffix is found (e.g. "SHA256SUMS"), return as-is.
+ */
+function versionizeFilename(filename, version) {
+  const archMatch = filename.match(/^(.+?)_(x86_64|aarch64)(\..+)$/);
+  if (archMatch) {
+    return `${archMatch[1]}_${version}_${archMatch[2]}${archMatch[3]}`;
+  }
+  // No arch suffix — return unchanged (SHA256SUMS, etc.)
+  return filename;
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    // Only intercept /xiboplayer-kiosk/latest/<something>
+    const match = url.pathname.match(
+      /^\/xiboplayer-kiosk\/latest\/(.+)$/
+    );
+    if (!match) {
+      // Not a /latest/ request — passthrough to R2 origin
+      return fetch(request);
+    }
+
+    const requestedFilename = match[1];
+
+    // Read current version from R2
+    const version = await getLatestVersion(env.IMAGES_BUCKET);
+    if (!version) {
+      return new Response(
+        'LATEST version file not found in R2 bucket.\n' +
+        'Has a release been published via build-iso.yml?\n',
+        { status: 404, headers: { 'Content-Type': 'text/plain' } }
+      );
+    }
+
+    // Build the versioned target URL
+    const versionedFilename = versionizeFilename(requestedFilename, version);
+    const target = `${url.origin}/xiboplayer-kiosk/${version}/${versionedFilename}`;
+
+    // 302 Found — temporary redirect so the URL always re-checks
+    // LATEST on the next request (vs 301 which browsers cache
+    // permanently and would serve stale versions).
+    return Response.redirect(target, 302);
+  },
+};

--- a/workers/latest-redirect/wrangler.toml
+++ b/workers/latest-redirect/wrangler.toml
@@ -1,0 +1,37 @@
+# Cloudflare Worker: latest-redirect
+#
+# Redirects /xiboplayer-kiosk/latest/* to the versioned path on R2,
+# reading the current version from the LATEST file. Zero storage
+# duplication — just a 302 redirect.
+#
+# Deploy:
+#   cd workers/latest-redirect
+#   npx wrangler deploy
+#
+# Requires:
+#   - CLOUDFLARE_API_TOKEN env var (or `wrangler login`)
+#   - The R2 bucket name below must match the bucket that
+#     images.xiboplayer.org serves from
+
+name = "xiboplayer-kiosk-latest-redirect"
+main = "src/index.js"
+compatibility_date = "2025-01-01"
+
+# Route: only intercept /xiboplayer-kiosk/latest/* on the images domain.
+# All other requests (versioned paths, test paths, RPM repo, etc.)
+# fall through to R2's default serving behaviour.
+routes = [
+  { pattern = "images.xiboplayer.org/xiboplayer-kiosk/latest/*", zone_name = "xiboplayer.org" }
+]
+
+# R2 bucket binding — the Worker reads the LATEST file from this bucket
+# to determine the current version. The bucket is the same one that
+# build-iso.yml uploads images to and that images.xiboplayer.org serves.
+#
+# IMPORTANT: replace "xiboplayer-images" below with the actual R2
+# bucket name from your Cloudflare dashboard (R2 → Buckets → name).
+# The bucket name is a secret in GH Actions as R2_BUCKET but Workers
+# need it in wrangler.toml as a plain binding.
+[[r2_buckets]]
+binding = "IMAGES_BUCKET"
+bucket_name = "xiboplayer-images"  # ← UPDATE if your bucket has a different name


### PR DESCRIPTION
On tag pushes, \`atomic.yml\` now also pushes kiosk-version-specific tags to GHCR:

\`\`\`
ghcr.io/xibo-players/xiboplayer-kiosk:v0.4.35-x86_64
ghcr.io/xibo-players/xiboplayer-kiosk:v0.4.35-aarch64
ghcr.io/xibo-players/xiboplayer-kiosk:v0.4.35    ← multi-arch manifest
\`\`\`

Alongside the existing floating tags (\`:43\`, \`:43-x86_64\`, \`:43-aarch64\`, \`:latest\`) which continue to be updated on every build.

## Why

Operators running \`bootc switch :43\` get whatever was last pushed — no way to know which kiosk version it contains or to rollback. With version tags:

\`\`\`bash
# Pin to a specific release
bootc switch ghcr.io/xibo-players/xiboplayer-kiosk:v0.4.35

# Rollback
bootc switch ghcr.io/xibo-players/xiboplayer-kiosk:v0.4.34
\`\`\`

## Tag scheme

| Tag | When pushed | Stability |
|---|---|---|
| \`:v0.4.35\` | Tag push only | **Immutable** — never overwritten |
| \`:v0.4.35-x86_64\` | Tag push only | Immutable |
| \`:v0.4.35-aarch64\` | Tag push only | Immutable |
| \`:43\` | Every build | **Floating** — tracks latest Fedora 43 build |
| \`:latest\` | Every build | Floating — tracks latest of any Fedora |

## Also in this PR

Deleted 5 stale GHCR OCI-artifact packages (\`/iso\`, \`/qcow2\`, \`/raw-x86_64\`, \`/raw-aarch64\`, \`/checksums\`) at v0.4.9 from March 30 — pushed by an old workflow that no longer exists. ISOs/QCOW2/raw ship via R2 CDN + GitHub Release; the bootc container stays on GHCR.

## Non-tag builds unaffected

Main branch pushes, weekly schedule, and manual dispatch only produce the floating \`:43\` + \`:latest\` tags — no version tag, since those builds don't correspond to a release.