### PR TITLE
ci: pin build-iso.yml to .github#23 (retry on network errors)

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-iso.yml@bd8bb5b8c550210652a6aa1a7915df68b606a916  # main @ 2026-04-11 (iso-* customization inputs + R2 test prefix for fast test downloads — companion to #89)
+    uses: xibo-players/.github/.github/workflows/build-iso.yml@dbc7f59aefa3c643a95dbc8c401d70183f7ccc09  # main @ 2026-04-12 (retry on transient network errors — .github#23)
     with:
       package-name: xiboplayer-kiosk
       kickstart-file: 'kickstart/xiboplayer-kiosk.ks'

--- a/.github/workflows/test-image.yml
+++ b/.github/workflows/test-image.yml
@@ -52,7 +52,7 @@ concurrency:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-iso.yml@bd8bb5b8c550210652a6aa1a7915df68b606a916  # feat(build-iso): test builds also upload to R2 test prefix (#89 follow-up — fast download)
+    uses: xibo-players/.github/.github/workflows/build-iso.yml@dbc7f59aefa3c643a95dbc8c401d70183f7ccc09  # main @ 2026-04-12 (retry on transient network errors — .github#23)
     with:
       package-name: xiboplayer-kiosk
       kickstart-file: 'kickstart/xiboplayer-kiosk.ks'


### PR DESCRIPTION
Updates the SHA pin for the reusable \`build-iso.yml\` workflow from \`bd8bb5b\` → \`dbc7f59\` in both \`image.yml\` and \`test-image.yml\`.

The new \`.github\` commit (xibo-players/.github#23) adds \`retry_if_unreachable\` wrappers to 3 mirror-dependent steps + curl native retry for the Fedora ISO download. Only retries on transient network errors; fails immediately on real package errors.

Companion to xibo-players/.github#23 (already merged).