### PR TITLE
feat(kiosk): show version in Ctrl+I, welcome splash, and main menu

### DIFF
--- a/kiosk/xibo-first-boot.sh
+++ b/kiosk/xibo-first-boot.sh
@@ -458,7 +458,7 @@ welcome_splash() {
         --title="xiboplayer — First boot" \
         --window-icon="$XIBO_LOGO" \
         --width=560 \
-        --text="$(zlib_brand_header "Welcome — this is the first boot of this kiosk")
+        --text="$(zlib_brand_header "Welcome — this is the first boot of this kiosk — v${XIBO_KIOSK_VERSION}")
 
 The next screen lets you configure:
 
@@ -506,7 +506,7 @@ main_loop() {
         action=$(zenity --list \
             --title="xiboplayer — First boot setup" \
             --window-icon="$XIBO_LOGO" \
-            --text="$(zlib_brand_header "First boot setup — configure the kiosk, then press Start")" \
+            --text="$(zlib_brand_header "First boot setup — configure the kiosk, then press Start — v${XIBO_KIOSK_VERSION}")" \
             --ok-label="Start" \
             --column="Action" --column="Setting" --column="Current status" \
             --width=680 --height=480 \

--- a/kiosk/xibo-show-ip.sh
+++ b/kiosk/xibo-show-ip.sh
@@ -11,4 +11,5 @@ for svc in arexibo.service xiboplayer-electron.service xiboplayer-chromium.servi
 done
 CMS=$(grep -oP '"address"\s*:\s*"\K[^"]+' "${XIBO_DATA_DIR}/cms.json" 2>/dev/null || echo "not configured")
 PLAYER=$(basename "$(readlink /etc/alternatives/xiboplayer 2>/dev/null)" 2>/dev/null || echo "unknown")
-notify-send -t 5000 "Xibo Status" "IP: $IP\nCMS: $CMS\nPlayer: $PLAYER\nStatus: $STATUS"
+VERSION=$(rpm -q --queryformat '%{VERSION}-%{RELEASE}' xiboplayer-kiosk 2>/dev/null || echo "unknown")
+notify-send -t 8000 "Xibo Status" "IP: $IP\nVersion: $VERSION\nPlayer: $PLAYER\nCMS: $CMS\nStatus: $STATUS"

--- a/kiosk/xibo-zenity-lib.sh
+++ b/kiosk/xibo-zenity-lib.sh
@@ -137,6 +137,10 @@ zlib_status_keyboard() {
 # kiosk RPM.
 XIBO_LOGO="${XIBO_KIOSK_DIR}/xiboplayer-kiosk-logo.png"
 
+# Kiosk version — read once at lib load time. Used by the welcome
+# splash, the main menu subtitle, and the debug dump.
+XIBO_KIOSK_VERSION=$(rpm -q --queryformat '%{VERSION}' xiboplayer-kiosk 2>/dev/null || echo "dev")
+
 # zlib_brand <trailing text> — emit Pango markup with the branded
 # name followed by optional trailing text. Example:
 #   zlib_brand "— First boot setup"


### PR DESCRIPTION
Operators couldn't tell which kiosk version was installed without a terminal.

Version now visible in 3 places:
- **Ctrl+I notification**: "Version: 0.4.35-1.fc43"
- **Welcome splash subtitle**: "Welcome — … — v0.4.35"
- **Main menu subtitle**: "First boot setup — … — v0.4.35"

Version appended at end so primary text isn't displaced. Read from \`rpm -q\` once at lib-load time, falls back to "dev" on git checkouts.