### PR TITLE
feat(kiosk): add build date+time alongside version

### DIFF
--- a/kiosk/xibo-first-boot.sh
+++ b/kiosk/xibo-first-boot.sh
@@ -458,7 +458,7 @@ welcome_splash() {
         --title="xiboplayer — First boot" \
         --window-icon="$XIBO_LOGO" \
         --width=560 \
-        --text="$(zlib_brand_header "Welcome — this is the first boot of this kiosk — v${XIBO_KIOSK_VERSION}")
+        --text="$(zlib_brand_header "Welcome — this is the first boot of this kiosk — v${XIBO_KIOSK_VERSION} (${XIBO_KIOSK_BUILD_DATE})")
 
 The next screen lets you configure:
 
@@ -506,7 +506,7 @@ main_loop() {
         action=$(zenity --list \
             --title="xiboplayer — First boot setup" \
             --window-icon="$XIBO_LOGO" \
-            --text="$(zlib_brand_header "First boot setup — configure the kiosk, then press Start — v${XIBO_KIOSK_VERSION}")" \
+            --text="$(zlib_brand_header "First boot setup — configure the kiosk, then press Start — v${XIBO_KIOSK_VERSION} (${XIBO_KIOSK_BUILD_DATE})")" \
             --ok-label="Start" \
             --column="Action" --column="Setting" --column="Current status" \
             --width=680 --height=480 \

--- a/kiosk/xibo-show-ip.sh
+++ b/kiosk/xibo-show-ip.sh
@@ -12,4 +12,5 @@ done
 CMS=$(grep -oP '"address"\s*:\s*"\K[^"]+' "${XIBO_DATA_DIR}/cms.json" 2>/dev/null || echo "not configured")
 PLAYER=$(basename "$(readlink /etc/alternatives/xiboplayer 2>/dev/null)" 2>/dev/null || echo "unknown")
 VERSION=$(rpm -q --queryformat '%{VERSION}-%{RELEASE}' xiboplayer-kiosk 2>/dev/null || echo "unknown")
-notify-send -t 8000 "Xibo Status" "IP: $IP\nVersion: $VERSION\nPlayer: $PLAYER\nCMS: $CMS\nStatus: $STATUS"
+BUILD_DATE=$(rpm -q --queryformat '%{BUILDTIME:date}' xiboplayer-kiosk 2>/dev/null || echo "unknown")
+notify-send -t 8000 "Xibo Status" "IP: $IP\nVersion: $VERSION\nBuilt: $BUILD_DATE\nPlayer: $PLAYER\nCMS: $CMS\nStatus: $STATUS"

--- a/kiosk/xibo-zenity-lib.sh
+++ b/kiosk/xibo-zenity-lib.sh
@@ -137,9 +137,10 @@ zlib_status_keyboard() {
 # kiosk RPM.
 XIBO_LOGO="${XIBO_KIOSK_DIR}/xiboplayer-kiosk-logo.png"
 
-# Kiosk version — read once at lib load time. Used by the welcome
-# splash, the main menu subtitle, and the debug dump.
+# Kiosk version + build date — read once at lib load time. Used by
+# the welcome splash, the main menu subtitle, Ctrl+I, and debug dump.
 XIBO_KIOSK_VERSION=$(rpm -q --queryformat '%{VERSION}' xiboplayer-kiosk 2>/dev/null || echo "dev")
+XIBO_KIOSK_BUILD_DATE=$(rpm -q --queryformat '%{BUILDTIME:date}' xiboplayer-kiosk 2>/dev/null || echo "unknown")
 
 # zlib_brand <trailing text> — emit Pango markup with the branded
 # name followed by optional trailing text. Example:


### PR DESCRIPTION
Extends PR #108 with the RPM build timestamp via `rpm -q --queryformat '%{BUILDTIME:date}'`. Operators see version + exact build date+time in Ctrl+I, welcome splash, and main menu.