### PR TITLE
feat(kiosk): grub menu via xorriso post-patch + inst.ks= in grub.cfg

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-iso.yml@f32d3d5a326d587303ed66c32e5cc95bfb1179ba  # main @ 2026-04-12 (GPG non-fatal — .github#27)
+    uses: xibo-players/.github/.github/workflows/build-iso.yml@1c5db5f5dfbd2c6de64338544fb1b8a49ed49d0e  # main @ 2026-04-12 (xorriso post-patch for grub — .github#28)
     with:
       package-name: xiboplayer-kiosk
       kickstart-file: 'kickstart/xiboplayer-kiosk.ks'

--- a/.github/workflows/test-image.yml
+++ b/.github/workflows/test-image.yml
@@ -52,7 +52,7 @@ concurrency:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-iso.yml@f32d3d5a326d587303ed66c32e5cc95bfb1179ba  # main @ 2026-04-12 (GPG non-fatal — .github#27)
+    uses: xibo-players/.github/.github/workflows/build-iso.yml@1c5db5f5dfbd2c6de64338544fb1b8a49ed49d0e  # main @ 2026-04-12 (xorriso post-patch for grub — .github#28)
     with:
       package-name: xiboplayer-kiosk
       kickstart-file: 'kickstart/xiboplayer-kiosk.ks'

--- a/kickstart/grub.cfg
+++ b/kickstart/grub.cfg
@@ -1,17 +1,17 @@
 # xiboplayer kiosk — UEFI boot menu
 #
+# This file is injected INTO the ISO AFTER mkksiso finishes, via a
+# post-build xorriso patch step in build-iso.yml. It completely
+# replaces Fedora's default grub.cfg (and mkksiso's modifications).
+#
+# Because mkksiso no longer modifies this file, inst.ks= must be
+# included explicitly in every linuxefi line. The path matches
+# what mkksiso --ks places: /<kickstart-basename> at the ISO root.
+# The LABEL matches iso-volid set in image.yml / test-image.yml.
+#
 # All players (Chromium + Electron) are installed in every image.
-# The default entry uses Chromium; operator can pick Electron or
-# Arexibo from the Advanced > Choose default player submenu.
-# Player can also be switched at any time via the first-boot zenity
-# menu (Player row) or Ctrl+R after install.
-#
-# WARNING: every Install entry ERASES ALL DATA on the target disk.
-# The kickstart uses autopart with clearpart --all --initlabel.
-#
-# This file is injected into production ISOs via mkksiso --add
-# (grub.cfg overlay in build-iso.yml). The inst.ks= path is added
-# automatically by mkksiso --ks when embedding the kickstart.
+# The grub entry only sets the DEFAULT player via xibo.profile=.
+# Operator can switch at any time via the first-boot Player row.
 
 set default=0
 set timeout=10
@@ -26,12 +26,12 @@ set menu_color_highlight=white/blue
 # ── Main menu ─────────────────────────────────────────────────────
 
 menuentry 'Install xiboplayer-kiosk' --class fedora --class os {
-    linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER xibo.profile=chromium quiet
+    linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium quiet
     initrdefi /images/pxeboot/initrd.img
 }
 
 menuentry 'Verify media & install xiboplayer-kiosk' --class fedora --class os {
-    linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER rd.live.check xibo.profile=chromium quiet
+    linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks rd.live.check xibo.profile=chromium quiet
     initrdefi /images/pxeboot/initrd.img
 }
 
@@ -42,23 +42,23 @@ submenu 'Advanced options >' {
     submenu 'Choose default player >' {
 
         menuentry 'Chromium (recommended, lighter)' --class fedora --class os {
-            linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER xibo.profile=chromium quiet
+            linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium quiet
             initrdefi /images/pxeboot/initrd.img
         }
 
         menuentry 'Electron (heavier, more compatible)' --class fedora --class os {
-            linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER xibo.profile=electron quiet
+            linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=electron quiet
             initrdefi /images/pxeboot/initrd.img
         }
 
         menuentry 'Arexibo — Rust native (pulled from network)' --class fedora --class os {
-            linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER xibo.profile=arexibo quiet
+            linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=arexibo quiet
             initrdefi /images/pxeboot/initrd.img
         }
     }
 
     menuentry 'Install xiboplayer-kiosk — text mode' --class fedora --class os {
-        linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER xibo.profile=chromium inst.text quiet
+        linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.text quiet
         initrdefi /images/pxeboot/initrd.img
     }
 


### PR DESCRIPTION
grub.cfg now includes explicit inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks. build-iso.yml patches the ISO after mkksiso using xorriso -boot_image any replay -map.