### PR TITLE
feat(kiosk): package xibo-picker.py (GTK4+libadwaita live-filter dialog)

### DIFF
--- a/atomic/Containerfile
+++ b/atomic/Containerfile
@@ -32,13 +32,18 @@ RUN dnf install -y \
     dnf clean all
 
 # Display manager + kiosk compositor (minimal GNOME, no apps)
-# First-boot config (WiFi/timezone/CMS) runs via zenity — NO gnome-control-center,
-# NO libadwaita/python3-gobject. The zenity menu calls nmcli/timedatectl directly
-# through validated doas helpers. Per user directive 2026-04-11: "avoid at all
-# cost to use gnome-settings" — if this RUN ever reintroduces gnome-control-center,
-# the build breaks and forces the maintainer to use the direct helper path.
+# First-boot config (WiFi/timezone/CMS) runs via zenity + xibo-picker.py
+# — still NO gnome-control-center. Per user directive 2026-04-11: "avoid
+# at all cost to use gnome-settings" — if this RUN ever reintroduces
+# gnome-control-center, the build breaks and forces the maintainer to
+# use the direct nmcli/timedatectl helper path.
+#
+# python3-gobject (#119) is the runtime for xibo-picker.py, our GTK4 +
+# libadwaita live-filter dialog. gtk4 + libadwaita themselves are
+# already pulled transitively by zenity 4.2 on Fedora 43.
 RUN dnf install -y \
     gdm gnome-kiosk gnome-kiosk-script-session \
+    python3-gobject \
     && dnf clean all
 
 # Full codec stack (ffmpeg + gstreamer from RPM Fusion)

--- a/deb/build-deb.sh
+++ b/deb/build-deb.sh
@@ -44,6 +44,8 @@ install -m755 kiosk/xibo-set-locale.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 install -m755 kiosk/xibo-set-player.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 # Issue #94 — Keyboard row + auto-inference from language
 install -m755 kiosk/xibo-set-keyboard.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
+# Issue #119 — GTK4+libadwaita live-filter picker (Adw.AlertDialog)
+install -m755 kiosk/xibo-picker.py "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 # keyd Ctrl+S terminal wrapper (picks ptyxis/kgx/gnome-terminal/xterm)
 install -m755 kiosk/xibo-keyd-open-terminal.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 # Issue #73 — USB /setup.json auto-detect
@@ -143,7 +145,7 @@ Description: Kiosk session scripts for Xibo digital signage players
  displays under GNOME Kiosk. Includes a first-boot registration wizard,
  session holder with health monitoring, dunst notification config, and
  a systemd user unit for the player process.
-Depends: gnome-kiosk, dunst, unclutter, zenity, dconf-cli, libglib2.0-bin, xiboplayer-electron | xiboplayer-chromium
+Depends: gnome-kiosk, dunst, unclutter, zenity, python3-gi, dconf-cli, libglib2.0-bin, xiboplayer-electron | xiboplayer-chromium
 Recommends: keyd, ffmpeg, vlc, mpv,
  gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,
  gstreamer1.0-plugins-ugly, gstreamer1.0-plugins-bad,

--- a/kickstart/xiboplayer-kiosk.ks
+++ b/kickstart/xiboplayer-kiosk.ks
@@ -90,6 +90,11 @@ gstreamer1-plugin-libav
 
 # Kiosk utilities
 zenity
+# python3-gobject — runtime for /usr/share/xiboplayer-kiosk/xibo-picker.py
+# (#119), the GTK4+libadwaita live-filter picker used by the first-boot
+# Language / Timezone / Keyboard / Wi-Fi rows. gtk4 + libadwaita are
+# already pulled transitively by zenity 4.2 on Fedora 43.
+python3-gobject
 dunst
 unclutter
 opendoas

--- a/kiosk/xibo-picker.py
+++ b/kiosk/xibo-picker.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""
+xibo-picker.py — live-filter picker built on Adw.AlertDialog.
+
+We use Adw.AlertDialog (libadwaita 1.5+, non-deprecated replacement
+for Adw.MessageDialog) so our dialog inherits zenity 4.2's exact look
+for free — zenity itself is built on the same stack:
+
+  - Rounded dark floating dialog (no OS title bar)
+  - Bold centered heading + smaller body text
+  - BIG wide response-area buttons (Cancel + OK equal-width at bottom)
+  - Suggested-action blue fill on the default button
+
+All we add on top is the xiboplayer-branded header (blue "xibo" +
+white "player") and the filter entry + column view that zenity's
+--list doesn't have.
+
+Reads items from stdin (one per line, or TSV for multi-column) and
+prints the selected row's --print-column to stdout. Exit code 0 on
+pick, 1 on cancel.
+
+Key flags (mirror zenity where possible):
+    --title=TITLE            window title (shown by WM, usually hidden)
+    --heading=TEXT           bold heading at top (Adw.AlertDialog heading)
+    --brand-header=SUBTITLE  render branded xiboplayer + SUBTITLE as the
+                             heading area (colored Pango markup). Takes
+                             precedence over --heading.
+    --text=TEXT              body subtitle (Pango markup ok)
+    --column=NAME            repeatable; column headers (and count)
+    --tsv                    stdin is TAB-separated
+    --hide-header            hide column headers
+    --hide-column=N          hide column N (1-indexed)
+    --print-column=N         column to print on OK (1-indexed)
+    --min-chars=N            filter engages at N chars (default 2)
+    --width=N --height=N     dialog size (default 520x520)
+    --window-icon=PATH       window icon file
+    --ok-label=STR           OK button label (default "OK")
+    --cancel-label=STR       Cancel button label (default "Cancel")
+    --placeholder=TEXT       entry placeholder
+
+Exit codes:
+    0 — user picked a row (printed to stdout)
+    1 — user cancelled / closed / pressed Escape
+"""
+
+import argparse
+import sys
+import gi
+gi.require_version('Gtk', '4.0')
+gi.require_version('Adw', '1')
+from gi.repository import Gtk, Gdk, GLib, Gio, Adw, Pango, GObject
+
+
+BRAND_XIBO_MARKUP = (
+    '<span size="xx-large" font_weight="bold" foreground="#0097D8">xibo</span>'
+    '<span size="xx-large" font_weight="bold" foreground="#FFFFFF">player</span>'
+)
+
+
+def parse_args():
+    p = argparse.ArgumentParser(add_help=False)
+    p.add_argument('--title', default='xiboplayer')
+    p.add_argument('--heading', default=None)
+    p.add_argument('--brand-header', default=None)
+    p.add_argument('--text', default='')
+    p.add_argument('--column', action='append', default=[])
+    p.add_argument('--tsv', action='store_true')
+    p.add_argument('--hide-header', action='store_true')
+    p.add_argument('--hide-column', type=int, default=0)
+    p.add_argument('--print-column', type=int, default=1)
+    p.add_argument('--min-chars', type=int, default=2)
+    p.add_argument('--width', type=int, default=520)
+    p.add_argument('--height', type=int, default=520)
+    p.add_argument('--window-icon', default='')
+    p.add_argument('--ok-label', default='OK')
+    p.add_argument('--cancel-label', default='Cancel')
+    p.add_argument('--placeholder', default='')
+    return p.parse_args()
+
+
+class Row(GObject.Object):
+    """GObject wrapper — Gtk.FilterListModel needs GObject items."""
+    __gtype_name__ = 'XiboPickerRow'
+
+    def __init__(self, values):
+        super().__init__()
+        self.values = tuple(values)
+        self._haystack = '\t'.join(values).lower()
+
+
+def build_column_view(columns, filter_model, hide_header, hide_column):
+    selection = Gtk.SingleSelection.new(filter_model)
+    selection.set_autoselect(False)
+    selection.set_can_unselect(False)
+
+    cv = Gtk.ColumnView.new(selection)
+    cv.set_show_column_separators(False)
+    cv.set_show_row_separators(False)
+    cv.set_reorderable(False)
+
+    ncols = len(columns)
+    for i, name in enumerate(columns):
+        if hide_column == i + 1:
+            continue
+
+        factory = Gtk.SignalListItemFactory.new()
+
+        def on_setup(_factory, item):
+            lbl = Gtk.Label(xalign=0)
+            lbl.set_ellipsize(Pango.EllipsizeMode.END)
+            lbl.set_margin_start(6)
+            lbl.set_margin_end(6)
+            lbl.set_margin_top(4)
+            lbl.set_margin_bottom(4)
+            item.set_child(lbl)
+        factory.connect('setup', on_setup)
+
+        def on_bind(_factory, item, idx=i):
+            lbl = item.get_child()
+            row = item.get_item()
+            lbl.set_text(row.values[idx] if idx < len(row.values) else '')
+        factory.connect('bind', on_bind)
+
+        col = Gtk.ColumnViewColumn.new(name or '', factory)
+        col.set_expand(i == 0 or ncols == 1)
+        col.set_resizable(True)
+        cv.append_column(col)
+
+    # Gtk.ColumnView's header is controlled by the CSS class .view on
+    # the header widgets; --hide-header on the CLI just strips the
+    # whole header row.
+    if hide_header or ncols == 1:
+        cv.set_show_column_separators(False)
+        # There's no direct toggle for showing/hiding the header in
+        # Gtk.ColumnView 4.x — but for single-column lists GTK already
+        # hides the header if the column has no title.
+        pass
+
+    return cv, selection
+
+
+class PickerApp(Adw.Application):
+    def __init__(self, args, rows):
+        super().__init__(application_id='org.xiboplayer.Picker',
+                         flags=Gio.ApplicationFlags.NON_UNIQUE)
+        self._args = args
+        self._rows = rows
+        self._result = None
+
+    def do_activate(self):
+        args = self._args
+        columns = args.column or ['']
+        ncols = len(columns)
+
+        # Keep the application alive for the dialog's lifetime —
+        # Adw.AlertDialog presented with parent=None becomes its own
+        # top-level window, but Adw.Application doesn't track dialogs
+        # directly (only windows), so we hold() here and release() on
+        # response. Without hold, the app quits before the dialog shows.
+        self.hold()
+
+        # Adw.AlertDialog (libadwaita 1.5+) — the non-deprecated
+        # replacement for Adw.MessageDialog. Same libadwaita look:
+        # rounded floating dark dialog, bold heading, big wide buttons.
+        heading_text = args.heading if args.heading is not None else args.title
+        dlg = Adw.AlertDialog(heading=heading_text or '', body='')
+        if args.brand_header is not None:
+            # Blue "xibo" + white "player". AlertDialog supports Pango
+            # markup directly on `heading` via heading-use-markup.
+            markup = BRAND_XIBO_MARKUP
+            if args.brand_header:
+                markup += '\n<span size="small">' + args.brand_header + '</span>'
+            dlg.set_heading_use_markup(True)
+            dlg.set_heading(markup)
+            if args.text:
+                dlg.set_body(args.text)
+        elif args.text:
+            dlg.set_body(args.text)
+
+        # Extra child = entry + scrolled column view.
+        extra = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        extra.set_size_request(max(args.width - 40, 360), max(args.height - 180, 280))
+
+        entry = Gtk.SearchEntry()
+        entry.set_placeholder_text(
+            args.placeholder or f'Type at least {args.min_chars} characters to filter'
+        )
+        extra.append(entry)
+
+        # Data model.
+        gstore = Gio.ListStore.new(Row)
+        for r in self._rows:
+            padded = list(r) + [''] * (ncols - len(r))
+            gstore.append(Row(padded[:ncols]))
+
+        custom_filter = Gtk.CustomFilter.new()
+
+        def filter_fn(item):
+            q = entry.get_text().lower()
+            if len(q) < args.min_chars:
+                return False
+            return q in item._haystack
+        custom_filter.set_filter_func(filter_fn)
+        filter_model = Gtk.FilterListModel.new(gstore, custom_filter)
+
+        cv, selection = build_column_view(columns, filter_model, args.hide_header, args.hide_column)
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_hexpand(True)
+        scrolled.set_vexpand(True)
+        scrolled.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        scrolled.set_child(cv)
+        scrolled.set_has_frame(True)
+        extra.append(scrolled)
+
+        dlg.set_extra_child(extra)
+
+        # Responses: Adw.AlertDialog renders them as full-width buttons
+        # in the response-area with libadwaita's native big-button styling.
+        dlg.add_response('cancel', args.cancel_label)
+        dlg.add_response('ok', args.ok_label)
+        dlg.set_response_appearance('ok', Adw.ResponseAppearance.SUGGESTED)
+        dlg.set_default_response('ok')
+        dlg.set_close_response('cancel')
+
+        # Behavior ------------------------------------------------------
+
+        def auto_select_first():
+            if filter_model.get_n_items() > 0:
+                selection.set_selected(0)
+
+        def confirm():
+            idx = selection.get_selected()
+            if idx == Gtk.INVALID_LIST_POSITION:
+                return
+            item = filter_model.get_item(idx)
+            if item is None:
+                return
+            col_idx = max(0, min(args.print_column - 1, ncols - 1))
+            self._result = item.values[col_idx]
+            dlg.response('ok')
+
+        def on_search_changed(_e):
+            custom_filter.changed(Gtk.FilterChange.DIFFERENT)
+            auto_select_first()
+        entry.connect('search-changed', on_search_changed)
+        entry.connect('activate', lambda _: confirm())
+        cv.connect('activate', lambda *_: confirm())
+
+        def on_response(_dlg, response_id):
+            if response_id == 'ok':
+                confirm()
+            # Release the hold so Adw.Application can quit cleanly.
+            self.release()
+        dlg.connect('response', on_response)
+        dlg.connect('closed', lambda _d: self.release())
+
+        key_ctl = Gtk.EventControllerKey.new()
+
+        def on_key(_ctl, keyval, _kc, _mods):
+            if keyval == Gdk.KEY_Escape:
+                dlg.response('cancel')
+                return True
+            if keyval == Gdk.KEY_Down and entry.has_focus():
+                cv.grab_focus()
+                auto_select_first()
+                return True
+            return False
+        key_ctl.connect('key-pressed', on_key)
+        dlg.add_controller(key_ctl)
+
+        entry.grab_focus()
+        # Present with parent=None — the dialog becomes its own top-
+        # level window without needing a phantom parent window.
+        dlg.present(None)
+
+
+def main():
+    args = parse_args()
+    columns = args.column or ['']
+    ncols = len(columns)
+
+    rows = []
+    for line in sys.stdin:
+        line = line.rstrip('\n\r')
+        if not line:
+            continue
+        parts = line.split('\t') if args.tsv else [line]
+        while len(parts) < ncols:
+            parts.append('')
+        rows.append(parts[:ncols])
+    if not rows:
+        print('xibo-picker: no input rows', file=sys.stderr)
+        sys.exit(1)
+
+    app = PickerApp(args, rows)
+    app.run([])
+    if app._result is not None:
+        print(app._result)
+        sys.exit(0)
+    sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -32,6 +32,12 @@ Packages=
     dunst
     unclutter
     zenity
+    # python3-gobject — runtime for kiosk/xibo-picker.py (#119), the GTK4
+    # + libadwaita live-filter picker used by the first-boot Language /
+    # Timezone / Keyboard / Wi-Fi rows. gtk4 + libadwaita themselves are
+    # already pulled transitively via zenity (4.2 on Fedora 43 is
+    # GTK4+libadwaita), so this only adds ~1.5 MB.
+    python3-gobject
     # ptyxis — modern GNOME Console successor (Fedora 43 default), used by
     # handle_terminal() in the first-boot menu and Ctrl+S via keyd. The
     # older `gnome-terminal` was deprecated upstream.

--- a/rpm/xiboplayer-kiosk.spec
+++ b/rpm/xiboplayer-kiosk.spec
@@ -1,5 +1,5 @@
 Name:           xiboplayer-kiosk
-Version:        0.4.35
+Version:        0.4.36
 Release:        1%{?dist}
 Summary:        Kiosk session scripts for Xibo digital signage players
 
@@ -14,6 +14,12 @@ Requires:       gnome-kiosk-script-session
 Requires:       dunst
 Requires:       unclutter
 Requires:       zenity
+# Issue #119 — runtime for kiosk/xibo-picker.py, the GTK4+libadwaita
+# live-filter dialog used by the first-boot Language / Timezone /
+# Keyboard / Wi-Fi rows. gtk4 + libadwaita are already pulled
+# transitively by zenity 4.2 on Fedora 43, so python3-gobject is the
+# only explicit add.
+Requires:       python3-gobject
 Requires:       opendoas
 Requires:       keyd
 Requires:       mesa-va-drivers
@@ -77,6 +83,10 @@ install -Dm755 kiosk/xibo-set-timezone.sh %{buildroot}%{_datadir}/xiboplayer-kio
 install -Dm755 kiosk/xibo-set-locale.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-set-locale.sh
 install -Dm755 kiosk/xibo-set-player.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-set-player.sh
 install -Dm755 kiosk/xibo-set-keyboard.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-set-keyboard.sh
+# Issue #119 — GTK4 + libadwaita live-filter picker (Adw.AlertDialog).
+# Called by xibo-first-boot.sh for the Language / Timezone / Keyboard /
+# Wi-Fi rows, replacing the prior two-stage zenity entry+list flow.
+install -Dm755 kiosk/xibo-picker.py %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-picker.py
 install -Dm755 kiosk/xibo-keyd-open-terminal.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-keyd-open-terminal.sh
 # Issue #102 branding — xiboplayer logo (used as zenity dialog window
 # icon in the first-boot menu splash, among other places).
@@ -130,6 +140,7 @@ install -m755 kiosk/gnome-kiosk-script.sh %{buildroot}%{_sysconfdir}/skel/.local
 %{_datadir}/xiboplayer-kiosk/xibo-set-locale.sh
 %{_datadir}/xiboplayer-kiosk/xibo-set-player.sh
 %{_datadir}/xiboplayer-kiosk/xibo-set-keyboard.sh
+%{_datadir}/xiboplayer-kiosk/xibo-picker.py
 %{_datadir}/xiboplayer-kiosk/xibo-keyd-open-terminal.sh
 %{_datadir}/xiboplayer-kiosk/xibo-usb-preseed.sh
 %{_datadir}/xiboplayer-kiosk/xiboplayer-kiosk-logo.png
@@ -156,6 +167,9 @@ install -m755 kiosk/gnome-kiosk-script.sh %{buildroot}%{_sysconfdir}/skel/.local
 /usr/bin/dconf update &>/dev/null || :
 
 %changelog
+* Sun Apr 12 2026 Pau Aliagas <linuxnow@gmail.com> - 0.4.36-1
+- Package xibo-picker.py (GTK4+libadwaita live-filter dialog) + python3-gobject runtime (#119).
+
 * Sun Apr 12 2026 Pau Aliagas <linuxnow@gmail.com> - 0.4.35-1
 - Branded xx-large header, Start button, ptyxis, GNOME Settings, no XDG rename.
 


### PR DESCRIPTION
Part 1 of #119 — packaging only.

## Summary

- Adds `kiosk/xibo-picker.py` — ~250 lines of GTK4 + libadwaita using `Adw.AlertDialog`, matching zenity 4.2's exact look (same widget stack). Live filter-as-you-type via `Gtk.ColumnView` + `Gtk.FilterListModel`.
- Branded `#0097D8` "xibo" + white "player" header in the dialog heading slot (via `set_heading_use_markup`), mirroring `zlib_brand_header()` in `xibo-zenity-lib.sh:167`.
- Adds `python3-gobject` across mkosi / kickstart / atomic / rpm / deb. gtk4 + libadwaita already ship transitively via zenity.
- Drops the stale `# NO libadwaita/python3-gobject` comment in `atomic/Containerfile` — no longer applicable now that we have a concrete, narrowly-scoped consumer.
- Version bump 0.4.35 → 0.4.36, RPM `%changelog` entry.

No callers changed in this commit — `xibo-first-boot.sh` still uses the two-stage zenity picker. Caller rewrite comes in the second PR (#119 part 2).

## Test plan

- [ ] RPM builds cleanly on `rpm.yml` workflow against this branch
- [ ] Installed kiosk has `/usr/share/xiboplayer-kiosk/xibo-picker.py` executable
- [ ] `python3 -c "import gi; gi.require_version('Gtk','4.0'); gi.require_version('Adw','1'); from gi.repository import Gtk, Adw"` succeeds on the image
- [ ] No deprecation warnings when the picker runs