### PR TITLE
ci: pin build-iso.yml to .github#31 (patch ALL grub.cfg paths)

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-iso.yml@e82d435f5c737850c16c6a0cde08385b966a0faa  # main @ 2026-04-12 (xorriso outdev fix — .github#29)
+    uses: xibo-players/.github/.github/workflows/build-iso.yml@c7a9ea831d9088b3f48dedbc14906b6d32ab3e76  # main @ 2026-04-12 (patch all grub.cfg paths, not just /EFI/BOOT — .github#31)
     with:
       package-name: xiboplayer-kiosk
       kickstart-file: 'kickstart/xiboplayer-kiosk.ks'

--- a/.github/workflows/test-image.yml
+++ b/.github/workflows/test-image.yml
@@ -52,7 +52,7 @@ concurrency:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-iso.yml@e82d435f5c737850c16c6a0cde08385b966a0faa  # main @ 2026-04-12 (xorriso outdev fix — .github#29)
+    uses: xibo-players/.github/.github/workflows/build-iso.yml@c7a9ea831d9088b3f48dedbc14906b6d32ab3e76  # main @ 2026-04-12 (patch all grub.cfg paths, not just /EFI/BOOT — .github#31)
     with:
       package-name: xiboplayer-kiosk
       kickstart-file: 'kickstart/xiboplayer-kiosk.ks'


### PR DESCRIPTION
Bump the build-iso.yml reusable-workflow SHA pin to pick up [xibo-players/.github#31](https://github.com/xibo-players/.github/pull/31) — which patches **all** grub.cfg paths in the ISO (not just /EFI/BOOT).

## Root cause of the recurring "Install Fedora 43" regression

Fedora ISOs ship grub.cfg at two locations:

- `/EFI/BOOT/grub.cfg` — Secure Boot UEFI path ✅ patched before
- `/boot/grub2/grub.cfg` — BIOS + some UEFI paths ❌ not patched before

We fixed one, tested on one boot path, declared victory. #31 enumerates grub.cfg paths at runtime and -map's ALL of them in one xorriso session, so any future Fedora layout change (e.g. a third path in F44) is covered automatically.

## Test plan

- [ ] Merge → trigger test-image.yml → verify log shows "Found 2 grub.cfg path(s)" + "patched successfully at 2 location(s)"
- [ ] Boot new ISO on BIOS → xiboplayer menu (was Fedora menu)
- [ ] Boot new ISO on Secure Boot UEFI → xiboplayer menu (unchanged)