### PR TITLE
fix(grub): use linux/initrd commands (not linuxefi/initrdefi)

### DIFF
--- a/kickstart/grub.cfg
+++ b/kickstart/grub.cfg
@@ -5,7 +5,7 @@
 # replaces Fedora's default grub.cfg (and mkksiso's modifications).
 #
 # Because mkksiso no longer modifies this file, inst.ks= must be
-# included explicitly in every linuxefi line. The path matches
+# included explicitly in every linux line. The path matches
 # what mkksiso --ks places: /<kickstart-basename> at the ISO root.
 # The LABEL matches iso-volid set in image.yml / test-image.yml.
 #
@@ -26,13 +26,13 @@ set menu_color_highlight=white/blue
 # ── Main menu ─────────────────────────────────────────────────────
 
 menuentry 'Install xiboplayer-kiosk' --class fedora --class os {
-    linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium quiet
-    initrdefi /images/pxeboot/initrd.img
+    linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium quiet
+    initrd /images/pxeboot/initrd.img
 }
 
 menuentry 'Verify media & install xiboplayer-kiosk' --class fedora --class os {
-    linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks rd.live.check xibo.profile=chromium quiet
-    initrdefi /images/pxeboot/initrd.img
+    linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks rd.live.check xibo.profile=chromium quiet
+    initrd /images/pxeboot/initrd.img
 }
 
 # ── Advanced options ──────────────────────────────────────────────
@@ -42,28 +42,28 @@ submenu 'Advanced options >' {
     submenu 'Choose default player >' {
 
         menuentry 'Chromium (recommended, lighter)' --class fedora --class os {
-            linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium quiet
-            initrdefi /images/pxeboot/initrd.img
+            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium quiet
+            initrd /images/pxeboot/initrd.img
         }
 
         menuentry 'Electron (heavier, more compatible)' --class fedora --class os {
-            linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=electron quiet
-            initrdefi /images/pxeboot/initrd.img
+            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=electron quiet
+            initrd /images/pxeboot/initrd.img
         }
 
         menuentry 'Arexibo — Rust native (pulled from network)' --class fedora --class os {
-            linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=arexibo quiet
-            initrdefi /images/pxeboot/initrd.img
+            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=arexibo quiet
+            initrd /images/pxeboot/initrd.img
         }
     }
 
     menuentry 'Install xiboplayer-kiosk — text mode' --class fedora --class os {
-        linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.text quiet
-        initrdefi /images/pxeboot/initrd.img
+        linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.text quiet
+        initrd /images/pxeboot/initrd.img
     }
 
     menuentry 'Rescue xiboplayer-kiosk system' --class fedora --class os {
-        linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.rescue quiet
-        initrdefi /images/pxeboot/initrd.img
+        linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.rescue quiet
+        initrd /images/pxeboot/initrd.img
     }
 }


### PR DESCRIPTION
Fedora 43's grub2 removed the legacy `linuxefi` / `initrdefi` EFI-specific commands — modern grub2 uses unified `linux` / `initrd` for both BIOS and UEFI.

Selecting any menu entry was producing:

```
error: can't find command 'linuxefi'
error: can't find command 'initrdefi'
```

Replaced across all 7 menu entries. Matches Fedora's own grub.cfg since F34.

Closes the final blocker on v0.4.36 ISO testing.