### PR TITLE
feat(grub): inst.noninteractive — zero-touch install, no hub screen

### DIFF
--- a/kickstart/grub.cfg
+++ b/kickstart/grub.cfg
@@ -26,12 +26,12 @@ set menu_color_highlight=white/blue
 # ── Main menu ─────────────────────────────────────────────────────
 
 menuentry 'Install xiboplayer-kiosk' --class fedora --class os {
-    linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium quiet
+    linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.noninteractive quiet
     initrd /images/pxeboot/initrd.img
 }
 
 menuentry 'Verify media & install xiboplayer-kiosk' --class fedora --class os {
-    linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks rd.live.check xibo.profile=chromium quiet
+    linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks rd.live.check xibo.profile=chromium inst.noninteractive quiet
     initrd /images/pxeboot/initrd.img
 }
 
@@ -42,23 +42,23 @@ submenu 'Advanced options >' {
     submenu 'Choose default player >' {
 
         menuentry 'Chromium (recommended, lighter)' --class fedora --class os {
-            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium quiet
+            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.noninteractive quiet
             initrd /images/pxeboot/initrd.img
         }
 
         menuentry 'Electron (heavier, more compatible)' --class fedora --class os {
-            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=electron quiet
+            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=electron inst.noninteractive quiet
             initrd /images/pxeboot/initrd.img
         }
 
         menuentry 'Arexibo — Rust native (pulled from network)' --class fedora --class os {
-            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=arexibo quiet
+            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=arexibo inst.noninteractive quiet
             initrd /images/pxeboot/initrd.img
         }
     }
 
     menuentry 'Install xiboplayer-kiosk — text mode' --class fedora --class os {
-        linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.text quiet
+        linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.noninteractive inst.text quiet
         initrd /images/pxeboot/initrd.img
     }
 


### PR DESCRIPTION
Adds `inst.noninteractive` to all 6 install menu entries in kickstart/grub.cfg so anaconda-gui skips the hub-and-spoke screen and goes straight to install progress. Our kickstart is already complete, so the hub was just a one-click speed bump defeating zero-touch. Rescue entry unchanged (inherently interactive).