### PR TITLE
fix(kickstart): add @^custom-environment so Software Selection spoke is complete

### DIFF
--- a/kickstart/xiboplayer-kiosk.ks
+++ b/kickstart/xiboplayer-kiosk.ks
@@ -57,6 +57,17 @@ bootloader --location=mbr --timeout=0 --append="quiet rhgb splash loglevel=3 rd.
 
 # Package selection
 %packages
+# Anaconda requires exactly one `@^environment` selection to consider the
+# Software Selection spoke complete. Without it the hub screen shows the
+# spoke with a warning triangle and blocks Begin Installation — and under
+# inst.noninteractive the install silently aborts. @^custom-environment
+# is the "I'll hand-pick everything" environment; we list @core, gdm,
+# gnome-kiosk, codecs, and our xiboplayer packages explicitly below.
+#
+# Reference: Fedora kickstart documentation — every kickstart MUST have
+# one environment group (single ^ prefix) regardless of individual
+# package picks.
+@^custom-environment
 @core
 @hardware-support
 


### PR DESCRIPTION
Anaconda requires one @^environment per kickstart. Our %packages had @core + packages but no environment, so Software Selection was marked incomplete — which is also why inst.noninteractive silently aborted last round.

@^custom-environment is Fedora's 'I'll pick my own packages' environment (verified via `dnf environment list` on F43). Zero extra packages pulled; just makes the spoke complete.

After this merges, we can safely re-add inst.noninteractive for true zero-touch install.