### PR TITLE
feat(grub): default to inst.text — zero-touch text install, skip hub

### DIFF
--- a/kickstart/grub.cfg
+++ b/kickstart/grub.cfg
@@ -26,12 +26,12 @@ set menu_color_highlight=white/blue
 # ── Main menu ─────────────────────────────────────────────────────
 
 menuentry 'Install xiboplayer-kiosk' --class fedora --class os {
-    linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium quiet
+    linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.text quiet
     initrd /images/pxeboot/initrd.img
 }
 
 menuentry 'Verify media & install xiboplayer-kiosk' --class fedora --class os {
-    linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks rd.live.check xibo.profile=chromium quiet
+    linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks rd.live.check xibo.profile=chromium inst.text quiet
     initrd /images/pxeboot/initrd.img
 }
 
@@ -42,24 +42,19 @@ submenu 'Advanced options >' {
     submenu 'Choose default player >' {
 
         menuentry 'Chromium (recommended, lighter)' --class fedora --class os {
-            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium quiet
+            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.text quiet
             initrd /images/pxeboot/initrd.img
         }
 
         menuentry 'Electron (heavier, more compatible)' --class fedora --class os {
-            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=electron quiet
+            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=electron inst.text quiet
             initrd /images/pxeboot/initrd.img
         }
 
         menuentry 'Arexibo — Rust native (pulled from network)' --class fedora --class os {
-            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=arexibo quiet
+            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=arexibo inst.text quiet
             initrd /images/pxeboot/initrd.img
         }
-    }
-
-    menuentry 'Install xiboplayer-kiosk — text mode' --class fedora --class os {
-        linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.text quiet
-        initrd /images/pxeboot/initrd.img
     }
 
     menuentry 'Rescue xiboplayer-kiosk system' --class fedora --class os {


### PR DESCRIPTION
All install menu entries now use inst.text. Text mode auto-proceeds with a complete kickstart (no hub click), has a percentage progress bar, and sidesteps the Software Selection exclusion-conflict warning. Unblocks first-boot-flow testing while we debug the graphical path separately.