### PR TITLE
feat(grub): restore and extend Advanced boot options

### DIFF
--- a/kickstart/grub.cfg
+++ b/kickstart/grub.cfg
@@ -57,6 +57,21 @@ submenu 'Advanced options >' {
         }
     }
 
+    menuentry 'Install with graphical installer (for debugging)' --class fedora --class os {
+        linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.graphical quiet
+        initrd /images/pxeboot/initrd.img
+    }
+
+    menuentry 'Install in basic graphics mode (nomodeset)' --class fedora --class os {
+        linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.text nomodeset quiet
+        initrd /images/pxeboot/initrd.img
+    }
+
+    menuentry 'Install with verbose kernel output (for debugging)' --class fedora --class os {
+        linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.text inst.debug systemd.log_level=debug
+        initrd /images/pxeboot/initrd.img
+    }
+
     menuentry 'Rescue xiboplayer-kiosk system' --class fedora --class os {
         linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.rescue quiet
         initrd /images/pxeboot/initrd.img


### PR DESCRIPTION
Adds graphical-install (debug), basic-graphics-mode (nomodeset), verbose-kernel-output (inst.debug) under Advanced options. Useful for edge-case hardware and install troubleshooting.