### PR TITLE
feat(grub): main entries back to graphical + noninteractive

### DIFF
--- a/kickstart/grub.cfg
+++ b/kickstart/grub.cfg
@@ -26,12 +26,12 @@ set menu_color_highlight=white/blue
 # ── Main menu ─────────────────────────────────────────────────────
 
 menuentry 'Install xiboplayer-kiosk' --class fedora --class os {
-    linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.text quiet
+    linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.noninteractive quiet
     initrd /images/pxeboot/initrd.img
 }
 
 menuentry 'Verify media & install xiboplayer-kiosk' --class fedora --class os {
-    linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks rd.live.check xibo.profile=chromium inst.text quiet
+    linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks rd.live.check xibo.profile=chromium inst.noninteractive quiet
     initrd /images/pxeboot/initrd.img
 }
 
@@ -42,17 +42,17 @@ submenu 'Advanced options >' {
     submenu 'Choose default player >' {
 
         menuentry 'Chromium (recommended, lighter)' --class fedora --class os {
-            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.text quiet
+            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.noninteractive quiet
             initrd /images/pxeboot/initrd.img
         }
 
         menuentry 'Electron (heavier, more compatible)' --class fedora --class os {
-            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=electron inst.text quiet
+            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=electron inst.noninteractive quiet
             initrd /images/pxeboot/initrd.img
         }
 
         menuentry 'Arexibo — Rust native (pulled from network)' --class fedora --class os {
-            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=arexibo inst.text quiet
+            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=arexibo inst.noninteractive quiet
             initrd /images/pxeboot/initrd.img
         }
     }
@@ -62,12 +62,12 @@ submenu 'Advanced options >' {
         initrd /images/pxeboot/initrd.img
     }
 
-    menuentry 'Install in basic graphics mode (nomodeset)' --class fedora --class os {
+    menuentry 'Install in basic graphics mode (nomodeset, text)' --class fedora --class os {
         linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.text nomodeset quiet
         initrd /images/pxeboot/initrd.img
     }
 
-    menuentry 'Install with verbose kernel output (for debugging)' --class fedora --class os {
+    menuentry 'Install with verbose kernel output (text, for debugging)' --class fedora --class os {
         linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.text inst.debug systemd.log_level=debug
         initrd /images/pxeboot/initrd.img
     }


### PR DESCRIPTION
Software Selection conflict fixed in #131, so noninteractive is safe again. Debug entries (nomodeset, verbose kernel) keep inst.text.