### PR TITLE
feat(grub): text mode default — zero-click install with yesterday's packages

### DIFF
--- a/kickstart/grub.cfg
+++ b/kickstart/grub.cfg
@@ -26,12 +26,12 @@ set menu_color_highlight=white/blue
 # ── Main menu ─────────────────────────────────────────────────────
 
 menuentry 'Install xiboplayer-kiosk' --class fedora --class os {
-    linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.noninteractive quiet
+    linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.text quiet
     initrd /images/pxeboot/initrd.img
 }
 
 menuentry 'Verify media & install xiboplayer-kiosk' --class fedora --class os {
-    linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks rd.live.check xibo.profile=chromium inst.noninteractive quiet
+    linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks rd.live.check xibo.profile=chromium inst.text quiet
     initrd /images/pxeboot/initrd.img
 }
 
@@ -42,17 +42,17 @@ submenu 'Advanced options >' {
     submenu 'Choose default player >' {
 
         menuentry 'Chromium (recommended, lighter)' --class fedora --class os {
-            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.noninteractive quiet
+            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=chromium inst.text quiet
             initrd /images/pxeboot/initrd.img
         }
 
         menuentry 'Electron (heavier, more compatible)' --class fedora --class os {
-            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=electron inst.noninteractive quiet
+            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=electron inst.text quiet
             initrd /images/pxeboot/initrd.img
         }
 
         menuentry 'Arexibo — Rust native (pulled from network)' --class fedora --class os {
-            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=arexibo inst.noninteractive quiet
+            linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=XIBOPLAYER inst.ks=hd:LABEL=XIBOPLAYER:/xiboplayer-kiosk.ks xibo.profile=arexibo inst.text quiet
             initrd /images/pxeboot/initrd.img
         }
     }


### PR DESCRIPTION
Text mode auto-proceeds despite the Software Selection warning from the xdg-user-dirs-gtk exclusion. No click-through needed. Graphical variant still available in Advanced submenu.