### PR TITLE
feat(first-boot): welcome splash + player picker + direct CMS + entry autofocus

### DIFF
--- a/kiosk/xibo-first-boot.sh
+++ b/kiosk/xibo-first-boot.sh
@@ -168,12 +168,16 @@ handle_timezone() {
 # each invocation writes the first-boot-done sentinel before
 # returning, and the sentinel is the gate that prevents auto-launch.
 handle_cms() {
-    if [ -x "$XIBO_KIOSK_DIR/xibo-show-cms.sh" ]; then
-        "$XIBO_KIOSK_DIR/xibo-show-cms.sh" || true
-    else
-        zenity --error --title="xiboplayer — CMS" --width=400 \
-            --window-icon="$XIBO_LOGO" \
-            --text="xibo-show-cms.sh not found — cannot configure CMS." 2>/dev/null
+    # Direct CMS configuration — goes straight to the URL/key/display-name
+    # form via zlib_cms_form + zlib_write_player_config. No intermediate
+    # reconfigure menu (that's what Ctrl+R is for, accessed via
+    # xibo-show-cms.sh). Matches user directive: "CMS leads to reconfig
+    # should be direct CMS config".
+    if zlib_cms_form; then
+        local player
+        player=$(python3 -c "import json; print(json.load(open('${HOME}/.config/xiboplayer/setup-result.json'))['player'])" 2>/dev/null || echo "Chromium")
+        zlib_write_player_config "$player" "$CMS_URL" "$CMS_KEY" "$DISPLAY_NAME"
+        zlib_notify "CMS configured: $CMS_URL"
     fi
 }
 
@@ -245,15 +249,23 @@ handle_player() {
     local current
     current=$(zlib_status_player)
 
+    # Live-filter picker (#119) — same GTK4+libadwaita dialog as the
+    # other pickers so the Player menu gets blue-OK + no-column-header
+    # styling consistent with Language / Timezone / Keyboard / Wi-Fi.
+    # min-chars=0 because we only have 2 rows — always show both.
     local pick
-    pick=$(zenity --list \
-        --title="xiboplayer — Player" \
-        --text="Current player: $current\n\nChoose which player runs on next session." \
-        --column="Player" --column="Description" \
-        --width=520 --height=260 \
-        "Chromium" "Chromium kiosk (default, lighter)" \
-        "Electron" "Electron wrapper (heavier, more compatible)" \
-        2>/dev/null) || return 0
+    pick=$(printf "Chromium\tChromium kiosk (default, lighter)\nElectron\tElectron wrapper (heavier, more compatible)\n" \
+        | "$XIBO_KIOSK_DIR/xibo-picker.py" --tsv \
+            --title="xiboplayer — Player" \
+            --brand-header="Player" \
+            --text="Current player: $current — choose which runs on next session." \
+            --column="Player" --column="Description" \
+            --hide-header \
+            --print-column=1 \
+            --min-chars=0 \
+            --width=560 --height=260 \
+            --window-icon="$XIBO_LOGO" \
+            2>/dev/null) || return 0
     [ -z "$pick" ] && return 0
 
     local arg
@@ -435,25 +447,18 @@ handle_settings() {
 # direction plus the deferred Option C in the consolidated plan's
 # "still pending" section.
 welcome_splash() {
-    zenity --info \
+    # Use xibo-picker.py --welcome (GTK4+libadwaita AlertDialog) so the
+    # logo PNG appears prominently to the left of the branded
+    # "xiboplayer" title, matching the visual style of the rest of the
+    # first-boot menu. The old zenity --info couldn't embed the logo
+    # image in the dialog body (only as the tiny title-bar window icon).
+    "$XIBO_KIOSK_DIR/xibo-picker.py" --welcome \
+        --logo="$XIBO_LOGO" \
         --title="xiboplayer — First boot" \
-        --window-icon="$XIBO_LOGO" \
-        --width=560 \
-        --text="$(zlib_brand_header "Welcome — this is the first boot of this kiosk — v${XIBO_KIOSK_VERSION} (${XIBO_KIOSK_BUILD_DATE})")
-
-The next screen lets you configure:
-
-  • Language and keyboard
-  • Wi-Fi or wired network
-  • Timezone
-  • Player (Chromium or Electron)
-  • CMS connection
-
-Advanced and diagnostic actions (terminal, GNOME Settings, debug bundle)
-live under the Settings row. When everything is ready, press Start to
-launch the player.
-
-Press OK to continue." \
+        --brand-header="Welcome — v${XIBO_KIOSK_VERSION} (${XIBO_KIOSK_BUILD_DATE})" \
+        --text="The next screen lets you configure Language, Keyboard, Wi-Fi, Timezone, Player, and CMS connection. Advanced and diagnostic actions live under the Settings row. Press Start when ready." \
+        --ok-label="Continue" \
+        --width=620 \
         2>/dev/null || true
 }
 

--- a/kiosk/xibo-picker.py
+++ b/kiosk/xibo-picker.py
@@ -63,6 +63,12 @@ def parse_args():
     p.add_argument('--heading', default=None)
     p.add_argument('--brand-header', default=None)
     p.add_argument('--text', default='')
+    # --welcome: info-splash mode (no list, no entry). Shows a horizontal
+    # header with the xiboplayer logo on the left and the branded brand
+    # + subtitle text on the right, followed by an OK button. Used by
+    # the first-boot welcome screen.
+    p.add_argument('--welcome', action='store_true')
+    p.add_argument('--logo', default='')
     p.add_argument('--column', action='append', default=[])
     p.add_argument('--tsv', action='store_true')
     p.add_argument('--hide-header', action='store_true')
@@ -126,15 +132,26 @@ def build_column_view(columns, filter_model, hide_header, hide_column):
         col.set_resizable(True)
         cv.append_column(col)
 
-    # Gtk.ColumnView's header is controlled by the CSS class .view on
-    # the header widgets; --hide-header on the CLI just strips the
-    # whole header row.
     if hide_header or ncols == 1:
-        cv.set_show_column_separators(False)
-        # There's no direct toggle for showing/hiding the header in
-        # Gtk.ColumnView 4.x — but for single-column lists GTK already
-        # hides the header if the column has no title.
-        pass
+        # Gtk.ColumnView has no public hide-header API in GTK 4.x.
+        # The header row is a child widget with node-name "header" —
+        # we hide it via a CSS provider scoped to this ColumnView
+        # instance (style class "hide-columnview-header" gate).
+        cv.add_css_class('hide-columnview-header')
+        css = Gtk.CssProvider()
+        css.load_from_data(
+            b'columnview.hide-columnview-header > header { '
+            b'  opacity: 0; min-height: 0; padding: 0; '
+            b'} '
+            b'columnview.hide-columnview-header > header > * { '
+            b'  min-height: 0; padding: 0; '
+            b'}'
+        )
+        Gtk.StyleContext.add_provider_for_display(
+            Gdk.Display.get_default(),
+            css,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
+        )
 
     return cv, selection
 
@@ -149,15 +166,85 @@ class PickerApp(Adw.Application):
 
     def do_activate(self):
         args = self._args
+        self.hold()
+
+        if args.welcome:
+            self._do_welcome()
+        else:
+            self._do_picker()
+
+    def _do_welcome(self):
+        """Welcome-splash mode: logo left, branded text right, OK button.
+
+        Used by xibo-first-boot.sh's welcome_splash() at the top of the
+        first-boot flow. No list, no entry — just an info dialog with
+        a prominent logo.
+        """
+        args = self._args
+        dlg = Adw.AlertDialog(heading='', body='')
+
+        # Horizontal box: logo on the left, text on the right.
+        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=16)
+        row.set_margin_top(4)
+        row.set_margin_bottom(4)
+        if args.logo:
+            try:
+                img = Gtk.Image.new_from_file(args.logo)
+                img.set_pixel_size(96)
+                img.set_valign(Gtk.Align.CENTER)
+                row.append(img)
+            except Exception:
+                pass
+
+        text_col = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
+        text_col.set_hexpand(True)
+        text_col.set_valign(Gtk.Align.CENTER)
+
+        brand = Gtk.Label()
+        brand.set_markup(BRAND_XIBO_MARKUP)
+        brand.set_xalign(0)
+        text_col.append(brand)
+
+        if args.brand_header:
+            sub = Gtk.Label()
+            sub.set_markup('<span size="medium">' + args.brand_header + '</span>')
+            sub.set_xalign(0)
+            sub.set_wrap(True)
+            text_col.append(sub)
+
+        row.append(text_col)
+
+        wrapper = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        wrapper.set_size_request(max(args.width - 40, 420), -1)
+        wrapper.append(row)
+
+        if args.text:
+            body = Gtk.Label()
+            body.set_markup(args.text)
+            body.set_xalign(0)
+            body.set_wrap(True)
+            body.set_margin_top(8)
+            wrapper.append(body)
+
+        dlg.set_extra_child(wrapper)
+
+        dlg.add_response('ok', args.ok_label)
+        dlg.set_response_appearance('ok', Adw.ResponseAppearance.SUGGESTED)
+        dlg.set_default_response('ok')
+        dlg.set_close_response('ok')
+
+        def on_response(_dlg, _response_id):
+            self._result = 'ok'  # any non-None → exit 0
+            self.release()
+        dlg.connect('response', on_response)
+        dlg.connect('closed', lambda _d: self.release())
+
+        dlg.present(None)
+
+    def _do_picker(self):
+        args = self._args
         columns = args.column or ['']
         ncols = len(columns)
-
-        # Keep the application alive for the dialog's lifetime —
-        # Adw.AlertDialog presented with parent=None becomes its own
-        # top-level window, but Adw.Application doesn't track dialogs
-        # directly (only windows), so we hold() here and release() on
-        # response. Without hold, the app quits before the dialog shows.
-        self.hold()
 
         # Adw.AlertDialog (libadwaita 1.5+) — the non-deprecated
         # replacement for Adw.MessageDialog. Same libadwaita look:
@@ -268,10 +355,15 @@ class PickerApp(Adw.Application):
         key_ctl.connect('key-pressed', on_key)
         dlg.add_controller(key_ctl)
 
-        entry.grab_focus()
         # Present with parent=None — the dialog becomes its own top-
         # level window without needing a phantom parent window.
         dlg.present(None)
+        # Grab focus AFTER present via idle_add, otherwise AdwAlertDialog's
+        # default-response button (the blue "OK") steals focus away from
+        # the entry and the operator has to click the entry before they
+        # can type. idle_add runs on the next GLib main-loop iteration,
+        # by which time the dialog's internal focus grab has completed.
+        GLib.idle_add(entry.grab_focus)
 
 
 def main():


### PR DESCRIPTION
Four picker-polish fixes in one PR: logo-left welcome, GLib.idle_add entry focus, handle_player uses xibo-picker.py, handle_cms skips reconfigure menu. Also fixes ColumnView header hiding via CSS.