### PR TITLE
feat(kiosk): Python + GTK4 + libadwaita first-boot wizard (0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0 (2026-04-13)
+
+First-boot + reconfigure wizard rewritten in **Python + GTK4 + libadwaita** with a GNOME Settings-style **sidebar + content** layout (`Adw.NavigationSplitView`). Replaces the zenity/shell/`xibo-picker.py` patchwork with a single `Adw.ApplicationWindow` where the 7 categories (Language / Keyboard / Wi-Fi / Timezone / Player / CMS / Settings) live as persistent sidebar rows with live status subtitles, and the selected category's UI renders inline in the right pane — no new windows for sub-screens. Picker input fields use `Adw.EntryRow` matching the CMS form style, Esc closes pickers, filter-as-you-type with live `Gtk.FilterListModel`, xiboplayer logo on the welcome page. Old shell scripts (`xibo-first-boot.sh` etc.) remain installed but no longer invoked — removed in 0.5.1. 54 unit tests covering branding / preseed / doas_runner / state / cms writers / wifi parser / locale filter / status probes.
+
 ## 0.4.35 (2026-04-12)
 
 First-boot menu polish + packaging fixes: **xx-large branded header** (blue `xibo` + white `player` Pango at `xx-large` size in every dialog), **"Start" button** replaces "OK" and the "done" row (click Start without a selection to launch the player), **ptyxis** replaces `gnome-terminal` for the terminal option and the Ctrl+S keyd binding (Fedora 43 default), **GNOME Settings** added as an optional escape hatch in the Settings sub-menu (`gnome-control-center`), **XDG rename prompt suppressed** (removed `xdg-user-dirs-gtk` + `enabled=False` in `/etc/xdg/user-dirs.conf`, so ~/Downloads etc. stay in English after a locale change).

--- a/deb/build-deb.sh
+++ b/deb/build-deb.sh
@@ -46,6 +46,14 @@ install -m755 kiosk/xibo-set-player.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 install -m755 kiosk/xibo-set-keyboard.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 # Issue #119 — GTK4+libadwaita live-filter picker (Adw.AlertDialog)
 install -m755 kiosk/xibo-picker.py "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
+# PR1+PR2 (Python rewrite) — library + services + dialogs + entry-points.
+install -d "${DEB_DIR}/usr/share/xiboplayer-kiosk/xiboplayer_kiosk/services"
+install -d "${DEB_DIR}/usr/share/xiboplayer-kiosk/xiboplayer_kiosk/dialogs"
+install -m644 kiosk/xiboplayer_kiosk/*.py              "${DEB_DIR}/usr/share/xiboplayer-kiosk/xiboplayer_kiosk/"
+install -m644 kiosk/xiboplayer_kiosk/services/*.py     "${DEB_DIR}/usr/share/xiboplayer-kiosk/xiboplayer_kiosk/services/"
+install -m644 kiosk/xiboplayer_kiosk/dialogs/*.py      "${DEB_DIR}/usr/share/xiboplayer-kiosk/xiboplayer_kiosk/dialogs/"
+install -m755 kiosk/xibo-first-boot  "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
+install -m755 kiosk/xibo-reconfigure "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 # keyd Ctrl+S terminal wrapper (picks ptyxis/kgx/gnome-terminal/xterm)
 install -m755 kiosk/xibo-keyd-open-terminal.sh "${DEB_DIR}/usr/share/xiboplayer-kiosk/"
 # Issue #73 — USB /setup.json auto-detect

--- a/kickstart/xiboplayer-kiosk.ks
+++ b/kickstart/xiboplayer-kiosk.ks
@@ -100,10 +100,16 @@ wireguard-tools
 openssh-server
 
 # ── GPU / VA-API drivers ───────────────────────────────────────
+# NOTE: intel-media-driver (iHD, RPM Fusion non-free) and
+# libva-nvidia-driver (RPM Fusion non-free) are installed in %post
+# AFTER xiboplayer-release enables the RPM Fusion repos. Listing them
+# here would cause anaconda to fail with "No match for argument:
+# intel-media-driver" at stage-1 package resolution — RPM Fusion is
+# not available to the installer until xiboplayer-release runs. The
+# mesa-* drivers below ARE in Fedora's default repos and ship here.
 mesa-dri-drivers
 mesa-va-drivers
 mesa-vulkan-drivers
-intel-media-driver
 libva
 
 # ── Fonts ──────────────────────────────────────────────────────
@@ -121,7 +127,10 @@ python3-gobject
 dunst
 unclutter
 opendoas
-keyd
+# NOTE: keyd is a COPR package (Requires: keyd on the xiboplayer-kiosk
+# RPM, pulled transitively once xiboplayer-release enables the COPR in
+# %post). Listing it here causes "No match for argument: keyd" at
+# anaconda stage-1 — the COPR isn't enabled yet.
 ptyxis
 vim-enhanced
 jq

--- a/kickstart/xiboplayer-kiosk.ks
+++ b/kickstart/xiboplayer-kiosk.ks
@@ -74,7 +74,14 @@ bootloader --location=mbr --timeout=0 --append="quiet rhgb splash loglevel=3 rd.
 # earlier --ignoremissing detour.
 
 # ── Environment ────────────────────────────────────────────────
-@^minimal-environment
+# `@^custom-environment` is the ONLY environment ID present on F43
+# (verified via `dnf environment list`). `@^minimal-environment` was
+# assumed by an earlier lean rewrite but does not exist as an
+# installable environment in F43 — referencing it leaves Software
+# Selection unsatisfied and anaconda opens the spoke at install time.
+# `custom-environment` adds zero packages by itself; we explicitly
+# list everything the kiosk needs below.
+@^custom-environment
 
 # ── Display manager + kiosk compositor ─────────────────────────
 gdm

--- a/kiosk/gnome-kiosk-script.xibo.sh
+++ b/kiosk/gnome-kiosk-script.xibo.sh
@@ -77,9 +77,17 @@ wpctl set-volume @DEFAULT_AUDIO_SINK@ 0.9 2>/dev/null || true
 #   - Can be deleted manually (or by Ctrl+R "full-setup") to re-run the menu.
 mkdir -p "$XIBO_DATA_DIR" 2>/dev/null || true
 FIRST_BOOT_SENTINEL="$XIBO_DATA_DIR/first-boot-done"
-if [ ! -f "$FIRST_BOOT_SENTINEL" ] && [ -x "$XIBO_KIOSK_DIR/xibo-first-boot.sh" ]; then
-    "$XIBO_KIOSK_DIR/xibo-first-boot.sh" 2>&1 | logger -t xibo-first-boot || true
-    touch "$FIRST_BOOT_SENTINEL" 2>/dev/null || true
+# First-boot wizard: prefer the Python wrapper (PR1/PR2 rewrite); fall
+# back to the old shell script if the Python one is missing (defensive
+# for mixed-version installs).
+if [ ! -f "$FIRST_BOOT_SENTINEL" ]; then
+    if [ -x "$XIBO_KIOSK_DIR/xibo-first-boot" ]; then
+        "$XIBO_KIOSK_DIR/xibo-first-boot" 2>&1 | logger -t xibo-first-boot || true
+        touch "$FIRST_BOOT_SENTINEL" 2>/dev/null || true
+    elif [ -x "$XIBO_KIOSK_DIR/xibo-first-boot.sh" ]; then
+        "$XIBO_KIOSK_DIR/xibo-first-boot.sh" 2>&1 | logger -t xibo-first-boot || true
+        touch "$FIRST_BOOT_SENTINEL" 2>/dev/null || true
+    fi
 fi
 
 # Helper: get IP address

--- a/kiosk/keyd-xibo.conf
+++ b/kiosk/keyd-xibo.conf
@@ -6,7 +6,7 @@ leftcontrol = layer(xibo_ctrl)
 
 [xibo_ctrl:C]
 i = command(/usr/share/xiboplayer-kiosk/xibo-keyd-run.sh /usr/share/xiboplayer-kiosk/xibo-show-ip.sh)
-r = command(/usr/share/xiboplayer-kiosk/xibo-keyd-run.sh /usr/share/xiboplayer-kiosk/xibo-show-cms.sh)
+r = command(/usr/share/xiboplayer-kiosk/xibo-keyd-run.sh /usr/share/xiboplayer-kiosk/xibo-reconfigure)
 d = command(/usr/share/xiboplayer-kiosk/xibo-keyd-run.sh /usr/share/xiboplayer-kiosk/xibo-debug-dump.sh)
 # Ctrl+S opens a shell via the shared wrapper. Not Ctrl+T — Chromium
 # intercepts Ctrl+T as "new tab" even in kiosk mode, so that binding

--- a/kiosk/xibo-first-boot
+++ b/kiosk/xibo-first-boot
@@ -1,0 +1,11 @@
+#!/bin/sh
+# xibo-first-boot — thin wrapper that launches the Python wizard.
+#
+# Invoked by kiosk/gnome-kiosk-script.xibo.sh once per fresh install (the
+# first-boot-done sentinel in ~/.local/share/xibo/ prevents subsequent
+# runs). Sets PYTHONPATH so the package tree at
+# /usr/share/xiboplayer-kiosk/xiboplayer_kiosk/ is importable, then
+# exec's the __main__ module in first-boot mode.
+set -e
+export PYTHONPATH="/usr/share/xiboplayer-kiosk${PYTHONPATH:+:${PYTHONPATH}}"
+exec python3 -m xiboplayer_kiosk --mode=first-boot "$@"

--- a/kiosk/xibo-reconfigure
+++ b/kiosk/xibo-reconfigure
@@ -1,0 +1,9 @@
+#!/bin/sh
+# xibo-reconfigure — thin wrapper for Ctrl+R reconfigure flow.
+#
+# Bound to Ctrl+R via kiosk/keyd-xibo.conf. Launches the Python wizard
+# in reconfigure mode, which presents ReconfigureMenu (edit CMS / re-run
+# full setup / open Settings / close) rather than the first-boot flow.
+set -e
+export PYTHONPATH="/usr/share/xiboplayer-kiosk${PYTHONPATH:+:${PYTHONPATH}}"
+exec python3 -m xiboplayer_kiosk --mode=reconfigure "$@"

--- a/kiosk/xiboplayer_kiosk/.gitignore
+++ b/kiosk/xiboplayer_kiosk/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/kiosk/xiboplayer_kiosk/__init__.py
+++ b/kiosk/xiboplayer_kiosk/__init__.py
@@ -1,0 +1,10 @@
+"""xiboplayer_kiosk — Python package for the first-boot + reconfigure wizard.
+
+Replaces kiosk/xibo-first-boot.sh + xibo-show-cms.sh + xibo-zenity-lib.sh +
+xibo-picker.py with a single GTK4+libadwaita application. See the blueprint
+in docs/ (or the #PR1-PR4 sequence of PRs) for architecture.
+"""
+
+from .branding import BRAND_HEADING_MARKUP, BRAND_XIBO, BRAND_PLAYER, LOGO_PATH  # noqa: F401
+
+__version__ = "0.4.36"

--- a/kiosk/xiboplayer_kiosk/__init__.py
+++ b/kiosk/xiboplayer_kiosk/__init__.py
@@ -7,4 +7,4 @@ in docs/ (or the #PR1-PR4 sequence of PRs) for architecture.
 
 from .branding import BRAND_HEADING_MARKUP, BRAND_XIBO, BRAND_PLAYER, LOGO_PATH  # noqa: F401
 
-__version__ = "0.4.36"
+__version__ = "0.5.0"

--- a/kiosk/xiboplayer_kiosk/__main__.py
+++ b/kiosk/xiboplayer_kiosk/__main__.py
@@ -1,0 +1,36 @@
+"""Entry-point for `python3 -m xiboplayer_kiosk`.
+
+Parses a single ``--mode`` flag selecting which flow to present:
+- ``first-boot`` (default): Welcome splash → Main menu → dispatches to pickers
+- ``reconfigure``: Reconfigure menu (Ctrl+R entry after first-boot is done)
+
+The shell wrappers ``/usr/share/xiboplayer-kiosk/xibo-first-boot`` and
+``xibo-reconfigure`` invoke this module with the appropriate mode.
+"""
+
+import argparse
+import sys
+
+from .app import KioskApp
+
+
+def main() -> int:
+    """Build argument parser, run the Adw.Application, return exit code."""
+    parser = argparse.ArgumentParser(
+        prog="xiboplayer-kiosk-wizard",
+        description="xiboplayer kiosk first-boot and reconfigure wizard.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["first-boot", "reconfigure"],
+        default="first-boot",
+        help="Which flow to present.",
+    )
+    args = parser.parse_args()
+
+    app = KioskApp(mode=args.mode)
+    return app.run([])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/kiosk/xiboplayer_kiosk/app.py
+++ b/kiosk/xiboplayer_kiosk/app.py
@@ -128,9 +128,9 @@ class KioskApp(Adw.Application):
         rows = [(z,) for z in tz_svc.list_timezones()]
         panel = PickerPanel(
             rows=rows,
-            columns=["IANA timezone"],
+            columns=[""],  # blank column header — IANA is jargon for the operator
             min_chars=2,
-            placeholder="Type a city, region, or UTC (e.g. New_York, London, Tokyo)",
+            placeholder="Type UTC or a city (e.g. UTC, New_York, London, Tokyo)",
             apply_label="Set timezone",
             on_apply=lambda v: self._apply_via_doas("xibo-set-timezone.sh", v, "Timezone"),
         )

--- a/kiosk/xiboplayer_kiosk/app.py
+++ b/kiosk/xiboplayer_kiosk/app.py
@@ -33,15 +33,23 @@ from .dialogs.wifi_password import WifiPasswordDialog
 
 
 def _apply_dark_theme() -> None:
-    """Mirror zenity: honour GNOME color-scheme preference."""
+    """Honour GNOME's color-scheme preference via Adw.StyleManager.
+
+    libadwaita has its own color-scheme property that is the canonical
+    way to set light/dark for Adwaita apps. The older GTK property
+    `gtk-application-prefer-dark-theme` still works but prints a
+    deprecation warning on every app start when libadwaita is active.
+    """
     try:
         s = Gio.Settings.new("org.gnome.desktop.interface")
         cs = s.get_string("color-scheme") if "color-scheme" in s.list_keys() else ""
-        prefer_dark = (cs == "prefer-dark")
-        from gi.repository import Gtk
-        Gtk.Settings.get_default().set_property(
-            "gtk-application-prefer-dark-theme", prefer_dark,
-        )
+        mgr = Adw.StyleManager.get_default()
+        if cs == "prefer-dark":
+            mgr.set_color_scheme(Adw.ColorScheme.FORCE_DARK)
+        elif cs == "prefer-light":
+            mgr.set_color_scheme(Adw.ColorScheme.FORCE_LIGHT)
+        else:
+            mgr.set_color_scheme(Adw.ColorScheme.PREFER_DARK)
     except Exception:  # noqa: BLE001
         pass
 

--- a/kiosk/xiboplayer_kiosk/app.py
+++ b/kiosk/xiboplayer_kiosk/app.py
@@ -130,7 +130,7 @@ class KioskApp(Adw.Application):
             rows=rows,
             columns=["IANA timezone"],
             min_chars=2,
-            placeholder="Type a city or region (e.g. Madrid, Europe, UTC)",
+            placeholder="Type a city, region, or UTC (e.g. New_York, London, Tokyo)",
             apply_label="Set timezone",
             on_apply=lambda v: self._apply_via_doas("xibo-set-timezone.sh", v, "Timezone"),
         )

--- a/kiosk/xiboplayer_kiosk/app.py
+++ b/kiosk/xiboplayer_kiosk/app.py
@@ -91,13 +91,16 @@ class KioskApp(Adw.Application):
 
     def _present_main_menu(self) -> None:
         assert self.state is not None
+        # MainMenu wires response → on_start internally; we don't need
+        # a second `connect("response", ...)` here. Doing both caused
+        # _finish() (= release) to fire twice → GLib-GIO-CRITICAL
+        # 'g_application_release: use_count > 0' assertion failure.
         self._main_menu = MainMenu(
             self.state,
             version=self._version(),
             on_pick=self._on_main_pick,
             on_start=self._finish,
         )
-        self._main_menu.connect("response", lambda _d, rid: self._finish() if rid == "start" else None)
         self._main_menu.present(None)
 
     def _on_main_pick(self, action: str) -> None:

--- a/kiosk/xiboplayer_kiosk/app.py
+++ b/kiosk/xiboplayer_kiosk/app.py
@@ -1,0 +1,335 @@
+"""KioskApp — lifecycle owner for the first-boot + reconfigure wizards."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Adw, Gio, GLib  # noqa: E402
+
+from . import branding
+from .doas_runner import DoasRunner
+from .services import cms as cms_svc
+from .services import keyboard as kb_svc
+from .services import locale as locale_svc
+from .services import notify
+from .services import timezone as tz_svc
+from .services import wifi as wifi_svc
+from .state import KioskState
+from .dialogs.cms_form import CmsForm
+from .dialogs.info import ErrorDialog, InfoDialog
+from .dialogs.main_menu import MainMenu
+from .dialogs.picker import Picker
+from .dialogs.player_picker import PlayerPicker
+from .dialogs.reconfigure_menu import ReconfigureMenu
+from .dialogs.settings_menu import SettingsMenu
+from .dialogs.welcome import WelcomeSplash
+from .dialogs.wifi_password import WifiPasswordDialog
+
+
+def _apply_dark_theme() -> None:
+    """Mirror zenity: honour GNOME color-scheme preference."""
+    try:
+        s = Gio.Settings.new("org.gnome.desktop.interface")
+        cs = s.get_string("color-scheme") if "color-scheme" in s.list_keys() else ""
+        prefer_dark = (cs == "prefer-dark")
+        from gi.repository import Gtk
+        Gtk.Settings.get_default().set_property(
+            "gtk-application-prefer-dark-theme", prefer_dark,
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
+class KioskApp(Adw.Application):
+    def __init__(self, mode: str):
+        super().__init__(
+            application_id="org.xiboplayer.Kiosk",
+            flags=Gio.ApplicationFlags.NON_UNIQUE,
+        )
+        self.mode = mode
+        self.state: KioskState | None = None
+        self.doas = DoasRunner()
+        self._main_menu: MainMenu | None = None
+
+    def do_activate(self):  # noqa: D401, N802
+        self.hold()
+        _apply_dark_theme()
+        self.state = KioskState.load()
+        if self.mode == "reconfigure":
+            self._present_reconfigure()
+        else:
+            self._present_welcome()
+
+    # ── Welcome → Main flow ─────────────────────────────────────────────
+
+    def _present_welcome(self) -> None:
+        version = self._version()
+        build_date = self._build_date()
+        dlg = WelcomeSplash(version=version, build_date=build_date)
+        dlg.connect("response", self._on_welcome_response)
+        dlg.present(None)
+
+    def _on_welcome_response(self, _dlg, response_id: str) -> None:
+        if response_id == "continue":
+            self._present_main_menu()
+        else:
+            self._finish()
+
+    def _present_main_menu(self) -> None:
+        assert self.state is not None
+        self._main_menu = MainMenu(
+            self.state,
+            version=self._version(),
+            on_pick=self._on_main_pick,
+            on_start=self._finish,
+        )
+        self._main_menu.connect("response", lambda _d, rid: self._finish() if rid == "start" else None)
+        self._main_menu.present(None)
+
+    def _on_main_pick(self, action: str) -> None:
+        dispatch = {
+            "language": self._pick_language,
+            "keyboard": self._pick_keyboard,
+            "wifi":     self._pick_wifi,
+            "timezone": self._pick_timezone,
+            "player":   self._pick_player,
+            "cms":      self._form_cms,
+            "settings": self._open_settings,
+        }
+        fn = dispatch.get(action)
+        if fn:
+            fn()
+
+    # ── Pickers ─────────────────────────────────────────────────────────
+
+    def _pick_language(self) -> None:
+        rows = [(loc,) for loc in locale_svc.list_locales()]
+        p = Picker(
+            subtitle="Language",
+            body="Type a locale code (e.g. en, en_GB, ca, es, fr, de):",
+            rows=rows, columns=["Locale"], min_chars=2, hide_header=True,
+        )
+        p.connect("response", self._on_picker_response, "locale")
+        p._picker_obj = p  # keep reference; GObject holds itself but be safe
+        p.present(None)
+
+    def _pick_keyboard(self) -> None:
+        rows = [(x,) for x in kb_svc.list_layouts()]
+        p = Picker(
+            subtitle="Keyboard layout",
+            body="Type a layout code or country (e.g. us, es, fr, gb):",
+            rows=rows, columns=["Layout"], min_chars=2, hide_header=True,
+        )
+        p.connect("response", self._on_picker_response, "keyboard")
+        p.present(None)
+
+    def _pick_timezone(self) -> None:
+        rows = [(z,) for z in tz_svc.list_timezones()]
+        p = Picker(
+            subtitle="Timezone",
+            body="Type a city or region (e.g. Madrid, Europe, UTC):",
+            rows=rows, columns=["IANA timezone"], min_chars=2, hide_header=True,
+        )
+        p.connect("response", self._on_picker_response, "timezone")
+        p.present(None)
+
+    def _pick_wifi(self) -> None:
+        if not wifi_svc.has_wifi_hardware():
+            dlg = InfoDialog(subtitle="Wi-Fi", body="No wireless hardware detected. Use a wired connection instead.")
+            dlg.present(None)
+            return
+        wifi_svc.rescan()
+        GLib.timeout_add_seconds(2, self._pick_wifi_after_scan)
+
+    def _pick_wifi_after_scan(self) -> bool:
+        nets = wifi_svc.list_networks()
+        if not nets:
+            dlg = InfoDialog(subtitle="Wi-Fi", body="No Wi-Fi networks found. Try again or use wired.")
+            dlg.present(None)
+            return False
+        rows: list[tuple[str, ...]] = []
+        for n in nets:
+            name = ("* " if n.in_use else "") + n.ssid
+            rows.append((name, f"{n.signal}%", n.security))
+        p = Picker(
+            subtitle="Wi-Fi",
+            body="Select a network",
+            rows=rows, columns=["SSID", "Signal", "Security"],
+            min_chars=0, hide_header=False, print_column=1,
+        )
+        p.connect("response", self._on_wifi_picker_response)
+        p.present(None)
+        return False
+
+    def _on_wifi_picker_response(self, dlg, response_id: str) -> None:
+        if response_id != "ok":
+            return
+        ssid_with_marker = dlg.selected_value() or ""
+        ssid = ssid_with_marker[2:] if ssid_with_marker.startswith("* ") else ssid_with_marker
+        if not ssid:
+            return
+        # Look up security
+        security = next((n.security for n in wifi_svc.list_networks() if n.ssid == ssid), "open")
+        if security == "open":
+            self._connect_wifi(ssid, "")
+            return
+        pw_dlg = WifiPasswordDialog(ssid)
+        pw_dlg.connect("response", self._on_wifi_password_response, ssid)
+        pw_dlg.present(None)
+
+    def _on_wifi_password_response(self, dlg, response_id: str, ssid: str) -> None:
+        if response_id != "connect":
+            return
+        self._connect_wifi(ssid, dlg.password)
+
+    def _connect_wifi(self, ssid: str, psk: str) -> None:
+        notify.send(f"Connecting to {ssid}...")
+        ok, err = self.doas.run("xibo-set-wifi.sh", ssid, psk)
+        if ok:
+            notify.send(f"Wi-Fi connected to {ssid}")
+        else:
+            ErrorDialog(subtitle="Wi-Fi", body=f"Failed to connect to {ssid}.\n\n{err}").present(None)
+        if self._main_menu:
+            self._main_menu.refresh_rows()
+
+    def _pick_player(self) -> None:
+        assert self.state is not None
+        p = PlayerPicker(current=self.state.player)
+        p.connect("response", self._on_player_response)
+        p.present(None)
+
+    def _on_player_response(self, dlg, response_id: str) -> None:
+        if response_id != "switch":
+            return
+        choice = dlg.selected_player()
+        arg = "electron" if choice == "Electron" else "chromium"
+        ok, err = self.doas.run("xibo-set-player.sh", arg)
+        if ok:
+            InfoDialog(
+                subtitle="Player",
+                body=f"Player switched to {choice}.\n\nReboot the kiosk (or log out and back in) to start the new player.",
+            ).present(None)
+        else:
+            ErrorDialog(subtitle="Player", body=f"Failed to switch player.\n\n{err}").present(None)
+        if self._main_menu:
+            self._main_menu.refresh_rows()
+
+    def _on_picker_response(self, dlg, response_id: str, kind: str) -> None:
+        if response_id != "ok":
+            return
+        value = dlg.selected_value()
+        if not value:
+            return
+        helper = {
+            "locale": "xibo-set-locale.sh",
+            "keyboard": "xibo-set-keyboard.sh",
+            "timezone": "xibo-set-timezone.sh",
+        }[kind]
+        notify.send(f"Setting {kind} to {value}...")
+        ok, err = self.doas.run(helper, value)
+        if ok:
+            notify.send(f"{kind.capitalize()}: {value}")
+        else:
+            ErrorDialog(subtitle=kind.capitalize(), body=f"Failed to set {kind} to {value}.\n\n{err}").present(None)
+        if self._main_menu:
+            self._main_menu.refresh_rows()
+
+    # ── CMS form ────────────────────────────────────────────────────────
+
+    def _form_cms(self) -> None:
+        assert self.state is not None
+        s = self.state
+        dlg = CmsForm(
+            cms_url=s.cms_url if s.cms_url != "(not configured)" else s.preseed_vars.get("xibo.cms_url", ""),
+            cms_key=s.preseed_vars.get("xibo.cms_key", ""),
+            display_name=s.preseed_vars.get("xibo.display_name", ""),
+        )
+        dlg.connect("response", self._on_cms_response)
+        dlg.present(None)
+
+    def _on_cms_response(self, dlg, response_id: str) -> None:
+        if response_id != "save":
+            return
+        url, key, name = dlg.values()
+        assert self.state is not None
+        try:
+            cms_svc.write_for_player(
+                self.state.player, self.state.config_dir, self.state.data_dir, url, key, name,
+            )
+            notify.send(f"CMS configured: {url}")
+        except Exception as e:  # noqa: BLE001
+            ErrorDialog(subtitle="CMS", body=f"Failed to write CMS config:\n\n{e}").present(None)
+        if self._main_menu:
+            self._main_menu.refresh_rows()
+
+    # ── Settings ────────────────────────────────────────────────────────
+
+    def _open_settings(self) -> None:
+        dlg = SettingsMenu(on_pick=self._on_settings_pick)
+        dlg.present(None)
+
+    def _on_settings_pick(self, action: str) -> None:
+        if action == "terminal":
+            for cand in ("ptyxis", "kgx", "gnome-terminal", "xterm"):
+                try:
+                    subprocess.Popen([cand], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                    notify.send(f"Opened {cand}")
+                    return
+                except FileNotFoundError:
+                    continue
+            ErrorDialog(subtitle="Terminal", body="No terminal emulator found (tried ptyxis / kgx / gnome-terminal / xterm).").present(None)
+        elif action == "gnome":
+            try:
+                subprocess.Popen(["gnome-control-center"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                notify.send("Opened GNOME Settings")
+            except FileNotFoundError:
+                ErrorDialog(subtitle="GNOME Settings", body="gnome-control-center is not installed.").present(None)
+        elif action == "debug":
+            for cand in (self.state.kiosk_dir / "xibo-debug-dump.sh", Path("/usr/bin/xibo-debug-dump")):
+                if cand.exists():
+                    subprocess.Popen([str(cand)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                    return
+            ErrorDialog(subtitle="Debug", body="xibo-debug-dump not found.").present(None)
+
+    # ── Reconfigure flow (Ctrl+R entry) ─────────────────────────────────
+
+    def _present_reconfigure(self) -> None:
+        assert self.state is not None
+        dlg = ReconfigureMenu(self.state, on_pick=self._on_reconfigure_pick)
+        dlg.connect("response", lambda _d, rid: self._finish() if rid == "close" else None)
+        dlg.present(None)
+
+    def _on_reconfigure_pick(self, action: str) -> None:
+        if action == "cms":
+            self._form_cms()
+        elif action == "full":
+            # Reset first-boot sentinel + re-enter main menu
+            sentinel = self.state.data_dir / "first-boot-done"
+            try:
+                sentinel.unlink()
+            except FileNotFoundError:
+                pass
+            self._present_main_menu()
+        elif action == "settings":
+            self._open_settings()
+
+    # ── Lifecycle helpers ───────────────────────────────────────────────
+
+    def _finish(self) -> None:
+        self.release()
+
+    def _version(self) -> str:
+        try:
+            from . import __version__
+            return __version__
+        except Exception:  # noqa: BLE001
+            return ""
+
+    def _build_date(self) -> str:
+        return os.environ.get("XIBO_KIOSK_BUILD_DATE", "")

--- a/kiosk/xiboplayer_kiosk/app.py
+++ b/kiosk/xiboplayer_kiosk/app.py
@@ -1,4 +1,16 @@
-"""KioskApp — lifecycle owner for the first-boot + reconfigure wizards."""
+"""KioskApp — single-window controller (Adw.NavigationSplitView).
+
+Replaces the dialog-stacking model with a sidebar-and-content layout
+inspired by GNOME Settings / Control Center. The sidebar lists every
+configurable category (Language, Keyboard, Wi-Fi, Timezone, Player,
+CMS, Settings); the right pane swaps to the corresponding panel when
+the operator clicks a row. No dialogs pop for sub-screens — everything
+lives in one window.
+
+Modal exceptions:
+- Wi-Fi password (Adw.AlertDialog, because it's a transient secret prompt)
+- Info / Error feedback after each action (Adw.AlertDialog)
+"""
 
 from __future__ import annotations
 
@@ -21,25 +33,14 @@ from .services import notify
 from .services import timezone as tz_svc
 from .services import wifi as wifi_svc
 from .state import KioskState
-from .dialogs.cms_form import CmsForm
 from .dialogs.info import ErrorDialog, InfoDialog
-from .dialogs.main_menu import MainMenu
-from .dialogs.picker import Picker
-from .dialogs.player_picker import PlayerPicker
-from .dialogs.reconfigure_menu import ReconfigureMenu
-from .dialogs.settings_menu import SettingsMenu
-from .dialogs.welcome import WelcomeSplash
+from .dialogs.panels import CmsFormPanel, PickerPanel, PlayerPanel, SettingsPanel
+from .dialogs.window import KioskWindow
 from .dialogs.wifi_password import WifiPasswordDialog
 
 
 def _apply_dark_theme() -> None:
-    """Honour GNOME's color-scheme preference via Adw.StyleManager.
-
-    libadwaita has its own color-scheme property that is the canonical
-    way to set light/dark for Adwaita apps. The older GTK property
-    `gtk-application-prefer-dark-theme` still works but prints a
-    deprecation warning on every app start when libadwaita is active.
-    """
+    """Honour GNOME color-scheme preference via Adw.StyleManager."""
     try:
         s = Gio.Settings.new("org.gnome.desktop.interface")
         cs = s.get_string("color-scheme") if "color-scheme" in s.list_keys() else ""
@@ -55,6 +56,8 @@ def _apply_dark_theme() -> None:
 
 
 class KioskApp(Adw.Application):
+    """Adw.Application that owns the KioskWindow + per-category panels."""
+
     def __init__(self, mode: str):
         super().__init__(
             application_id="org.xiboplayer.Kiosk",
@@ -63,141 +66,128 @@ class KioskApp(Adw.Application):
         self.mode = mode
         self.state: KioskState | None = None
         self.doas = DoasRunner()
-        self._main_menu: MainMenu | None = None
+        self._window: KioskWindow | None = None
 
     def do_activate(self):  # noqa: D401, N802
-        self.hold()
+        """Build state, create the window, present it."""
         _apply_dark_theme()
         self.state = KioskState.load()
-        if self.mode == "reconfigure":
-            self._present_reconfigure()
-        else:
-            self._present_welcome()
-
-    # ── Welcome → Main flow ─────────────────────────────────────────────
-
-    def _present_welcome(self) -> None:
-        version = self._version()
-        build_date = self._build_date()
-        dlg = WelcomeSplash(version=version, build_date=build_date)
-        dlg.connect("response", self._on_welcome_response)
-        dlg.present(None)
-
-    def _on_welcome_response(self, _dlg, response_id: str) -> None:
-        if response_id == "continue":
-            self._present_main_menu()
-        else:
-            self._finish()
-
-    def _present_main_menu(self) -> None:
-        assert self.state is not None
-        # MainMenu wires response → on_start internally; we don't need
-        # a second `connect("response", ...)` here. Doing both caused
-        # _finish() (= release) to fire twice → GLib-GIO-CRITICAL
-        # 'g_application_release: use_count > 0' assertion failure.
-        self._main_menu = MainMenu(
+        self._window = KioskWindow(
+            self,
             self.state,
-            version=self._version(),
-            on_pick=self._on_main_pick,
+            on_pick=self._on_category,
             on_start=self._finish,
+            version=self._version(),
         )
-        self._main_menu.present(None)
+        self._window.present()
 
-    def _on_main_pick(self, action: str) -> None:
+    # ── category dispatch ───────────────────────────────────────────────
+
+    def _on_category(self, category: str) -> None:
+        """User clicked a sidebar row — swap the content panel."""
         dispatch = {
-            "language": self._pick_language,
-            "keyboard": self._pick_keyboard,
-            "wifi":     self._pick_wifi,
-            "timezone": self._pick_timezone,
-            "player":   self._pick_player,
-            "cms":      self._form_cms,
-            "settings": self._open_settings,
+            "language": self._show_language,
+            "keyboard": self._show_keyboard,
+            "wifi":     self._show_wifi,
+            "timezone": self._show_timezone,
+            "player":   self._show_player,
+            "cms":      self._show_cms,
+            "settings": self._show_settings,
         }
-        fn = dispatch.get(action)
+        fn = dispatch.get(category)
         if fn:
             fn()
 
-    # ── Pickers ─────────────────────────────────────────────────────────
+    # ── content panels ──────────────────────────────────────────────────
 
-    def _pick_language(self) -> None:
+    def _show_language(self) -> None:
         rows = [(loc,) for loc in locale_svc.list_locales()]
-        p = Picker(
-            subtitle="Language",
-            body="Type a locale code (e.g. en, en_GB, ca, es, fr, de):",
-            rows=rows, columns=["Locale"], min_chars=2, hide_header=True,
+        panel = PickerPanel(
+            rows=rows,
+            columns=["Locale"],
+            min_chars=2,
+            placeholder="Type a locale code (e.g. en, en_GB, ca, es, fr, de)",
+            apply_label="Set language",
+            on_apply=lambda v: self._apply_via_doas("xibo-set-locale.sh", v, "Language"),
         )
-        p.connect("response", self._on_picker_response, "locale")
-        p._picker_obj = p  # keep reference; GObject holds itself but be safe
-        p.present(None)
+        self._window.set_content_panel("Language", panel)
 
-    def _pick_keyboard(self) -> None:
+    def _show_keyboard(self) -> None:
         rows = [(x,) for x in kb_svc.list_layouts()]
-        p = Picker(
-            subtitle="Keyboard layout",
-            body="Type a layout code or country (e.g. us, es, fr, gb):",
-            rows=rows, columns=["Layout"], min_chars=2, hide_header=True,
+        panel = PickerPanel(
+            rows=rows,
+            columns=["Layout"],
+            min_chars=2,
+            placeholder="Type a layout code or country (e.g. us, es, fr, gb)",
+            apply_label="Set keyboard",
+            on_apply=lambda v: self._apply_via_doas("xibo-set-keyboard.sh", v, "Keyboard"),
         )
-        p.connect("response", self._on_picker_response, "keyboard")
-        p.present(None)
+        self._window.set_content_panel("Keyboard", panel)
 
-    def _pick_timezone(self) -> None:
+    def _show_timezone(self) -> None:
         rows = [(z,) for z in tz_svc.list_timezones()]
-        p = Picker(
-            subtitle="Timezone",
-            body="Type a city or region (e.g. Madrid, Europe, UTC):",
-            rows=rows, columns=["IANA timezone"], min_chars=2, hide_header=True,
+        panel = PickerPanel(
+            rows=rows,
+            columns=["IANA timezone"],
+            min_chars=2,
+            placeholder="Type a city or region (e.g. Madrid, Europe, UTC)",
+            apply_label="Set timezone",
+            on_apply=lambda v: self._apply_via_doas("xibo-set-timezone.sh", v, "Timezone"),
         )
-        p.connect("response", self._on_picker_response, "timezone")
-        p.present(None)
+        self._window.set_content_panel("Timezone", panel)
 
-    def _pick_wifi(self) -> None:
+    def _show_wifi(self) -> None:
         if not wifi_svc.has_wifi_hardware():
-            dlg = InfoDialog(subtitle="Wi-Fi", body="No wireless hardware detected. Use a wired connection instead.")
-            dlg.present(None)
+            self._window.set_content_panel(
+                "Wi-Fi",
+                self._info_status_widget(
+                    icon="network-wireless-disabled-symbolic",
+                    title="No wireless hardware",
+                    body="This kiosk has no Wi-Fi adapter. Use a wired connection.",
+                ),
+            )
             return
         wifi_svc.rescan()
-        GLib.timeout_add_seconds(2, self._pick_wifi_after_scan)
+        # Wait briefly for scan results before populating.
+        GLib.timeout_add_seconds(2, self._wifi_panel_populate)
 
-    def _pick_wifi_after_scan(self) -> bool:
+    def _wifi_panel_populate(self) -> bool:
         nets = wifi_svc.list_networks()
         if not nets:
-            dlg = InfoDialog(subtitle="Wi-Fi", body="No Wi-Fi networks found. Try again or use wired.")
-            dlg.present(None)
+            self._window.set_content_panel(
+                "Wi-Fi",
+                self._info_status_widget(
+                    icon="network-wireless-symbolic",
+                    title="No networks found",
+                    body="Try again in a moment, or use a wired connection.",
+                ),
+            )
             return False
         rows: list[tuple[str, ...]] = []
         for n in nets:
             name = ("* " if n.in_use else "") + n.ssid
             rows.append((name, f"{n.signal}%", n.security))
-        p = Picker(
-            subtitle="Wi-Fi",
-            body="Select a network",
-            rows=rows, columns=["SSID", "Signal", "Security"],
-            min_chars=0, hide_header=False, print_column=1,
+        panel = PickerPanel(
+            rows=rows,
+            columns=["SSID", "Signal", "Security"],
+            min_chars=0,
+            placeholder="Filter networks",
+            apply_label="Connect",
+            on_apply=self._wifi_apply,
         )
-        p.connect("response", self._on_wifi_picker_response)
-        p.present(None)
+        self._window.set_content_panel("Wi-Fi", panel)
         return False
 
-    def _on_wifi_picker_response(self, dlg, response_id: str) -> None:
-        if response_id != "ok":
-            return
-        ssid_with_marker = dlg.selected_value() or ""
+    def _wifi_apply(self, ssid_with_marker: str) -> None:
         ssid = ssid_with_marker[2:] if ssid_with_marker.startswith("* ") else ssid_with_marker
-        if not ssid:
-            return
-        # Look up security
         security = next((n.security for n in wifi_svc.list_networks() if n.ssid == ssid), "open")
         if security == "open":
             self._connect_wifi(ssid, "")
             return
-        pw_dlg = WifiPasswordDialog(ssid)
-        pw_dlg.connect("response", self._on_wifi_password_response, ssid)
-        pw_dlg.present(None)
-
-    def _on_wifi_password_response(self, dlg, response_id: str, ssid: str) -> None:
-        if response_id != "connect":
-            return
-        self._connect_wifi(ssid, dlg.password)
+        # Password is sensitive — keep as a transient AlertDialog.
+        pw = WifiPasswordDialog(ssid)
+        pw.connect("response", lambda _d, rid: self._connect_wifi(ssid, pw.password) if rid == "connect" else None)
+        pw.present(self._window)
 
     def _connect_wifi(self, ssid: str, psk: str) -> None:
         notify.send(f"Connecting to {ssid}...")
@@ -205,87 +195,51 @@ class KioskApp(Adw.Application):
         if ok:
             notify.send(f"Wi-Fi connected to {ssid}")
         else:
-            ErrorDialog(subtitle="Wi-Fi", body=f"Failed to connect to {ssid}.\n\n{err}").present(None)
-        if self._main_menu:
-            self._main_menu.refresh_rows()
+            ErrorDialog(subtitle="Wi-Fi", body=f"Failed to connect to {ssid}.\n\n{err}").present(self._window)
+        self._window.refresh_sidebar()
 
-    def _pick_player(self) -> None:
-        assert self.state is not None
-        p = PlayerPicker(current=self.state.player)
-        p.connect("response", self._on_player_response)
-        p.present(None)
+    def _show_player(self) -> None:
+        panel = PlayerPanel(
+            current=self.state.player,
+            on_apply=self._player_apply,
+        )
+        self._window.set_content_panel("Player", panel)
 
-    def _on_player_response(self, dlg, response_id: str) -> None:
-        if response_id != "switch":
-            return
-        choice = dlg.selected_player()
+    def _player_apply(self, choice: str) -> None:
         arg = "electron" if choice == "Electron" else "chromium"
         ok, err = self.doas.run("xibo-set-player.sh", arg)
         if ok:
             InfoDialog(
                 subtitle="Player",
-                body=f"Player switched to {choice}.\n\nReboot the kiosk (or log out and back in) to start the new player.",
-            ).present(None)
+                body=f"Player switched to {choice}. Reboot (or log out + back in) to apply.",
+            ).present(self._window)
         else:
-            ErrorDialog(subtitle="Player", body=f"Failed to switch player.\n\n{err}").present(None)
-        if self._main_menu:
-            self._main_menu.refresh_rows()
+            ErrorDialog(subtitle="Player", body=f"Failed to switch player.\n\n{err}").present(self._window)
+        self._window.refresh_sidebar()
 
-    def _on_picker_response(self, dlg, response_id: str, kind: str) -> None:
-        if response_id != "ok":
-            return
-        value = dlg.selected_value()
-        if not value:
-            return
-        helper = {
-            "locale": "xibo-set-locale.sh",
-            "keyboard": "xibo-set-keyboard.sh",
-            "timezone": "xibo-set-timezone.sh",
-        }[kind]
-        notify.send(f"Setting {kind} to {value}...")
-        ok, err = self.doas.run(helper, value)
-        if ok:
-            notify.send(f"{kind.capitalize()}: {value}")
-        else:
-            ErrorDialog(subtitle=kind.capitalize(), body=f"Failed to set {kind} to {value}.\n\n{err}").present(None)
-        if self._main_menu:
-            self._main_menu.refresh_rows()
-
-    # ── CMS form ────────────────────────────────────────────────────────
-
-    def _form_cms(self) -> None:
-        assert self.state is not None
+    def _show_cms(self) -> None:
         s = self.state
-        dlg = CmsForm(
+        panel = CmsFormPanel(
             cms_url=s.cms_url if s.cms_url != "(not configured)" else s.preseed_vars.get("xibo.cms_url", ""),
             cms_key=s.preseed_vars.get("xibo.cms_key", ""),
             display_name=s.preseed_vars.get("xibo.display_name", ""),
+            on_apply=self._cms_apply,
         )
-        dlg.connect("response", self._on_cms_response)
-        dlg.present(None)
+        self._window.set_content_panel("CMS", panel)
 
-    def _on_cms_response(self, dlg, response_id: str) -> None:
-        if response_id != "save":
-            return
-        url, key, name = dlg.values()
-        assert self.state is not None
+    def _cms_apply(self, url: str, key: str, name: str) -> None:
         try:
-            cms_svc.write_for_player(
-                self.state.player, self.state.config_dir, self.state.data_dir, url, key, name,
-            )
+            cms_svc.write_for_player(self.state.player, self.state.config_dir, self.state.data_dir, url, key, name)
             notify.send(f"CMS configured: {url}")
         except Exception as e:  # noqa: BLE001
-            ErrorDialog(subtitle="CMS", body=f"Failed to write CMS config:\n\n{e}").present(None)
-        if self._main_menu:
-            self._main_menu.refresh_rows()
+            ErrorDialog(subtitle="CMS", body=f"Failed to write CMS config:\n\n{e}").present(self._window)
+        self._window.refresh_sidebar()
 
-    # ── Settings ────────────────────────────────────────────────────────
+    def _show_settings(self) -> None:
+        panel = SettingsPanel(on_pick=self._settings_pick)
+        self._window.set_content_panel("Settings", panel)
 
-    def _open_settings(self) -> None:
-        dlg = SettingsMenu(on_pick=self._on_settings_pick)
-        dlg.present(None)
-
-    def _on_settings_pick(self, action: str) -> None:
+    def _settings_pick(self, action: str) -> None:
         if action == "terminal":
             for cand in ("ptyxis", "kgx", "gnome-terminal", "xterm"):
                 try:
@@ -294,46 +248,42 @@ class KioskApp(Adw.Application):
                     return
                 except FileNotFoundError:
                     continue
-            ErrorDialog(subtitle="Terminal", body="No terminal emulator found (tried ptyxis / kgx / gnome-terminal / xterm).").present(None)
+            ErrorDialog(subtitle="Terminal", body="No terminal emulator installed.").present(self._window)
         elif action == "gnome":
             try:
                 subprocess.Popen(["gnome-control-center"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
                 notify.send("Opened GNOME Settings")
             except FileNotFoundError:
-                ErrorDialog(subtitle="GNOME Settings", body="gnome-control-center is not installed.").present(None)
+                ErrorDialog(subtitle="GNOME Settings", body="gnome-control-center is not installed.").present(self._window)
         elif action == "debug":
             for cand in (self.state.kiosk_dir / "xibo-debug-dump.sh", Path("/usr/bin/xibo-debug-dump")):
                 if cand.exists():
                     subprocess.Popen([str(cand)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                    notify.send("Debug bundle generation started")
                     return
-            ErrorDialog(subtitle="Debug", body="xibo-debug-dump not found.").present(None)
+            ErrorDialog(subtitle="Debug", body="xibo-debug-dump not found.").present(self._window)
 
-    # ── Reconfigure flow (Ctrl+R entry) ─────────────────────────────────
+    # ── helpers ─────────────────────────────────────────────────────────
 
-    def _present_reconfigure(self) -> None:
-        assert self.state is not None
-        dlg = ReconfigureMenu(self.state, on_pick=self._on_reconfigure_pick)
-        dlg.connect("response", lambda _d, rid: self._finish() if rid == "close" else None)
-        dlg.present(None)
+    def _apply_via_doas(self, helper: str, value: str, label: str) -> None:
+        notify.send(f"Setting {label.lower()} to {value}...")
+        ok, err = self.doas.run(helper, value)
+        if ok:
+            notify.send(f"{label}: {value}")
+        else:
+            ErrorDialog(subtitle=label, body=f"Failed to set {label} to {value}.\n\n{err}").present(self._window)
+        self._window.refresh_sidebar()
 
-    def _on_reconfigure_pick(self, action: str) -> None:
-        if action == "cms":
-            self._form_cms()
-        elif action == "full":
-            # Reset first-boot sentinel + re-enter main menu
-            sentinel = self.state.data_dir / "first-boot-done"
-            try:
-                sentinel.unlink()
-            except FileNotFoundError:
-                pass
-            self._present_main_menu()
-        elif action == "settings":
-            self._open_settings()
-
-    # ── Lifecycle helpers ───────────────────────────────────────────────
+    def _info_status_widget(self, *, icon: str, title: str, body: str) -> Adw.StatusPage:
+        sp = Adw.StatusPage()
+        sp.set_icon_name(icon)
+        sp.set_title(title)
+        sp.set_description(body)
+        return sp
 
     def _finish(self) -> None:
-        self.release()
+        if self._window is not None:
+            self._window.close()
 
     def _version(self) -> str:
         try:
@@ -341,6 +291,3 @@ class KioskApp(Adw.Application):
             return __version__
         except Exception:  # noqa: BLE001
             return ""
-
-    def _build_date(self) -> str:
-        return os.environ.get("XIBO_KIOSK_BUILD_DATE", "")

--- a/kiosk/xiboplayer_kiosk/branding.py
+++ b/kiosk/xiboplayer_kiosk/branding.py
@@ -1,0 +1,48 @@
+"""Branding constants — single source of truth for colors, markup, logo."""
+
+from pathlib import Path
+
+# Canonical colors from kiosk/xibo-zenity-lib.sh:167 and reference_xiboplayer_branding
+BRAND_XIBO_COLOR = "#0097D8"  # cyan "xibo"
+BRAND_PLAYER_COLOR = "#FFFFFF"  # white "player"
+
+BRAND_XIBO = f'<span font_weight="bold" foreground="{BRAND_XIBO_COLOR}">xibo</span>'
+BRAND_PLAYER = f'<span font_weight="bold" foreground="{BRAND_PLAYER_COLOR}">player</span>'
+
+# xx-large for the prominent heading slots (welcome splash, main menu title)
+BRAND_HEADING_MARKUP = (
+    f'<span size="xx-large" font_weight="bold" foreground="{BRAND_XIBO_COLOR}">xibo</span>'
+    f'<span size="xx-large" font_weight="bold" foreground="{BRAND_PLAYER_COLOR}">player</span>'
+)
+
+# Logo image shipped by the kiosk RPM at /usr/share/xiboplayer-kiosk/
+LOGO_PATH = Path("/usr/share/xiboplayer-kiosk/xiboplayer-kiosk-logo.png")
+
+
+def branded_heading(subtitle: str = "") -> str:
+    """Produce Pango markup for a dialog heading.
+
+    Parameters
+    ----------
+    subtitle
+        Small grey text shown below the bold "xiboplayer" line.
+        Typical values: ``"Language"``, ``"First boot setup — v0.4.36"``.
+        If empty, only the brand name is rendered.
+
+    Returns
+    -------
+    str
+        A single Pango-markup string suitable for ``Adw.AlertDialog.set_heading``
+        when ``set_heading_use_markup(True)`` has been called, or for a
+        ``Gtk.Label.set_markup`` call in a custom widget.
+
+    Examples
+    --------
+    >>> markup = branded_heading("Timezone")
+    >>> "xibo" in markup and "#0097D8" in markup
+    True
+    """
+    out = BRAND_HEADING_MARKUP
+    if subtitle:
+        out += "\n" + f'<span size="small">{subtitle}</span>'
+    return out

--- a/kiosk/xiboplayer_kiosk/branding.py
+++ b/kiosk/xiboplayer_kiosk/branding.py
@@ -1,5 +1,6 @@
 """Branding constants — single source of truth for colors, markup, logo."""
 
+import os
 from pathlib import Path
 
 # Canonical colors from kiosk/xibo-zenity-lib.sh:167 and reference_xiboplayer_branding
@@ -15,8 +16,16 @@ BRAND_HEADING_MARKUP = (
     f'<span size="xx-large" font_weight="bold" foreground="{BRAND_PLAYER_COLOR}">player</span>'
 )
 
-# Logo image shipped by the kiosk RPM at /usr/share/xiboplayer-kiosk/
-LOGO_PATH = Path("/usr/share/xiboplayer-kiosk/xiboplayer-kiosk-logo.png")
+# Logo image shipped by the kiosk RPM at /usr/share/xiboplayer-kiosk/.
+# Overridable via XIBO_KIOSK_LOGO env var so local dev runs can point at
+# the checked-out kiosk/xiboplayer-kiosk-logo.png before the package is
+# installed.
+LOGO_PATH = Path(
+    os.environ.get(
+        "XIBO_KIOSK_LOGO",
+        "/usr/share/xiboplayer-kiosk/xiboplayer-kiosk-logo.png",
+    ),
+)
 
 
 def branded_heading(subtitle: str = "") -> str:

--- a/kiosk/xiboplayer_kiosk/dialogs/__init__.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/__init__.py
@@ -1,0 +1,1 @@
+"""GTK4 + libadwaita dialog classes."""

--- a/kiosk/xiboplayer_kiosk/dialogs/base.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/base.py
@@ -1,0 +1,57 @@
+"""BrandedAlertDialog — shared ancestor for every kiosk dialog.
+
+Centralises:
+- branded heading (blue `xibo` + white `player` + optional subtitle) via
+  set_heading_use_markup(True)
+- SUGGESTED appearance on primary button
+- window icon from branding.LOGO_PATH (AlertDialog itself has no window, but
+  when it's its own top-level window the icon applies)
+- dark color-scheme preference (kiosk always runs dark)
+"""
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Adw, GLib, Gtk  # noqa: E402
+
+from ..branding import branded_heading
+
+
+class BrandedAlertDialog(Adw.AlertDialog):
+    """Parent for every kiosk dialog. Subclasses fill `extra_child` + responses."""
+
+    def __init__(self, *, heading_subtitle: str = "", body: str = ""):
+        super().__init__()
+        self.set_heading_use_markup(True)
+        self.set_heading(branded_heading(heading_subtitle))
+        if body:
+            self.set_body(body)
+        self._result = None
+
+    def add_suggested(self, response_id: str, label: str) -> None:
+        self.add_response(response_id, label)
+        self.set_response_appearance(response_id, Adw.ResponseAppearance.SUGGESTED)
+        self.set_default_response(response_id)
+
+    def add_destructive(self, response_id: str, label: str) -> None:
+        self.add_response(response_id, label)
+        self.set_response_appearance(response_id, Adw.ResponseAppearance.DESTRUCTIVE)
+
+    def add_cancel(self, label: str = "Cancel") -> None:
+        self.add_response("cancel", label)
+        self.set_close_response("cancel")
+
+    @property
+    def result(self):
+        return self._result
+
+    @result.setter
+    def result(self, v) -> None:
+        self._result = v
+
+    def focus_after_present(self, widget: Gtk.Widget) -> None:
+        """Shift focus to `widget` after presentation. Adw.AlertDialog's
+        default-response button steals focus synchronously; we use idle_add
+        so our focus grab wins the race."""
+        GLib.idle_add(widget.grab_focus)

--- a/kiosk/xiboplayer_kiosk/dialogs/cms_form.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/cms_form.py
@@ -1,0 +1,54 @@
+"""CmsForm — URL / Key / Display-name entry form."""
+
+from __future__ import annotations
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Adw, Gtk  # noqa: E402
+
+from .base import BrandedAlertDialog
+
+
+class CmsForm(BrandedAlertDialog):
+    def __init__(self, *, cms_url: str = "", cms_key: str = "", display_name: str = ""):
+        super().__init__(
+            heading_subtitle="CMS",
+            body="Enter your Xibo CMS server details",
+        )
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        box.set_size_request(480, -1)
+
+        group = Adw.PreferencesGroup()
+
+        self.url_row = Adw.EntryRow(title="CMS Server URL")
+        self.url_row.set_text(cms_url)
+        group.add(self.url_row)
+
+        self.key_row = Adw.PasswordEntryRow(title="CMS Key")
+        self.key_row.set_text(cms_key)
+        group.add(self.key_row)
+
+        self.name_row = Adw.EntryRow(title="Display Name")
+        self.name_row.set_text(display_name)
+        group.add(self.name_row)
+
+        box.append(group)
+        self.set_extra_child(box)
+
+        self.add_cancel()
+        self.add_suggested("save", "Save")
+
+        # Focus first empty row; else Save button
+        for row in (self.url_row, self.key_row, self.name_row):
+            if not row.get_text():
+                self.focus_after_present(row)
+                return
+
+    def values(self) -> tuple[str, str, str]:
+        url = self.url_row.get_text().strip()
+        if url and not url.endswith("/"):
+            url += "/"
+        return url, self.key_row.get_text().strip(), self.name_row.get_text().strip()

--- a/kiosk/xiboplayer_kiosk/dialogs/info.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/info.py
@@ -1,0 +1,27 @@
+"""Info + error helpers — branded replacements for zenity --info/--error."""
+
+from __future__ import annotations
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Adw  # noqa: E402
+
+from .base import BrandedAlertDialog
+
+
+class InfoDialog(BrandedAlertDialog):
+    def __init__(self, subtitle: str, body: str, ok_label: str = "OK"):
+        super().__init__(heading_subtitle=subtitle, body=body)
+        self.add_suggested("ok", ok_label)
+        self.set_close_response("ok")
+
+
+class ErrorDialog(BrandedAlertDialog):
+    def __init__(self, subtitle: str, body: str, ok_label: str = "OK"):
+        super().__init__(heading_subtitle=subtitle, body=body)
+        self.add_response("ok", ok_label)
+        self.set_response_appearance("ok", Adw.ResponseAppearance.DEFAULT)
+        self.set_default_response("ok")
+        self.set_close_response("ok")

--- a/kiosk/xiboplayer_kiosk/dialogs/main_menu.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/main_menu.py
@@ -1,0 +1,79 @@
+"""Main menu — 7 rows with live status column."""
+
+from __future__ import annotations
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Adw, GLib, Gtk  # noqa: E402
+
+from ..state import KioskState
+from .base import BrandedAlertDialog
+
+
+class MainMenu(BrandedAlertDialog):
+    """First-boot main menu. Status rendered from KioskState. Row activation
+    fires a callback the caller wires into the per-row handler."""
+
+    def __init__(self, state: KioskState, *, version: str = "", on_pick=None, on_start=None):
+        super().__init__(
+            heading_subtitle=(f"First boot setup — v{version}" if version else "First boot setup"),
+            body="",
+        )
+        self.state = state
+        self.on_pick = on_pick  # callable(action: str) -> None
+        self.on_start = on_start  # callable() -> None
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        box.set_size_request(560, -1)
+
+        self.group = Adw.PreferencesGroup()
+        self._rows: dict[str, Adw.ActionRow] = {}
+        self._build_rows()
+        box.append(self.group)
+
+        self.set_extra_child(box)
+
+        # Only one button — Start. No Cancel (escape = start too).
+        self.add_suggested("start", "Start player")
+        self.set_close_response("start")
+
+        self.connect("response", self._on_response)
+
+    def _build_rows(self) -> None:
+        for action, title, status in self._row_spec():
+            row = Adw.ActionRow(title=title, subtitle=status)
+            row.set_activatable(True)
+            row.connect("activated", self._on_row_activated, action)
+            # Right-arrow suffix for visual "this opens a dialog"
+            row.add_suffix(Gtk.Image.new_from_icon_name("go-next-symbolic"))
+            self.group.add(row)
+            self._rows[action] = row
+
+    def _row_spec(self) -> list[tuple[str, str, str]]:
+        s = self.state
+        return [
+            ("language", "Language", s.locale or "(unknown)"),
+            ("keyboard", "Keyboard", s.keyboard_layout),
+            ("wifi",     "Wi-Fi",    s.wifi_ssid),
+            ("timezone", "Timezone", s.timezone),
+            ("player",   "Player",   s.player),
+            ("cms",      "CMS",      s.cms_url),
+            ("settings", "Settings", ""),
+        ]
+
+    def refresh_rows(self) -> None:
+        """Re-render subtitles from current state (call after any setter)."""
+        self.state.refresh_all()
+        for action, _title, status in self._row_spec():
+            if action in self._rows:
+                self._rows[action].set_subtitle(status)
+
+    def _on_row_activated(self, _row, action: str) -> None:
+        if callable(self.on_pick):
+            self.on_pick(action)
+
+    def _on_response(self, _dlg, response_id: str) -> None:
+        if response_id == "start" and callable(self.on_start):
+            self.on_start()

--- a/kiosk/xiboplayer_kiosk/dialogs/panels.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/panels.py
@@ -302,8 +302,8 @@ class SettingsPanel(Gtk.Box):
 
         group = Adw.PreferencesGroup()
         for action_id, title, subtitle in (
-            ("terminal", "Open terminal", "ptyxis (Ctrl+S also works)"),
             ("gnome",    "GNOME Settings", "Advanced system tweaks"),
+            ("terminal", "Open terminal", "ptyxis (Ctrl+S also works)"),
             ("debug",    "Collect debug bundle", "~/Downloads/xibo-debug-*.tar.zst"),
         ):
             row = Adw.ActionRow(title=title, subtitle=subtitle)

--- a/kiosk/xiboplayer_kiosk/dialogs/panels.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/panels.py
@@ -1,0 +1,321 @@
+"""Embeddable panel widgets for the right-pane content of KioskWindow.
+
+These mirror the dialogs/* AlertDialog classes but as plain Gtk.Widgets
+(no dialog wrapper, no OK/Cancel buttons in chrome). Each panel
+fires a callback with the result; the controller (KioskApp) decides
+what happens next.
+
+Visual style mirrors the AlertDialog version: Adw.PreferencesGroup with
+Adw.EntryRow / Adw.PasswordEntryRow / Adw.ActionRow rows. Action area at
+the bottom of each panel for primary action (Apply / Connect / Save).
+"""
+
+from __future__ import annotations
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+gi.require_version("Gdk", "4.0")
+from gi.repository import Adw, Gdk, GObject, Gio, Gtk, Pango  # noqa: E402
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Picker panel — search entry + filtered ColumnView, embeddable.
+# ───────────────────────────────────────────────────────────────────────
+
+
+class _Row(GObject.Object):
+    __gtype_name__ = "XiboPanelRow"
+
+    def __init__(self, values: tuple[str, ...]):
+        super().__init__()
+        self.values = values
+        self._haystack = "\t".join(values).lower()
+
+
+class PickerPanel(Gtk.Box):
+    """Search-as-you-type panel for Language / Timezone / Keyboard / Wi-Fi.
+
+    Parameters
+    ----------
+    rows : list[tuple[str, ...]]
+        Each tuple is a row's column values.
+    columns : list[str]
+        Column titles. ``len(columns) == arity of each row tuple``.
+    print_column : int
+        1-indexed column whose value is returned in the ``apply`` callback.
+    min_chars : int
+        Filter engages once the search entry has this many characters.
+    placeholder : str
+        EntryRow title (acts as floating placeholder).
+    apply_label : str
+        Primary button label ("Apply" / "Connect" / etc.).
+    on_apply : Callable[[str], None]
+        Invoked with the selected value when the primary button fires.
+    """
+
+    __gsignals__ = {
+        "applied": (GObject.SignalFlags.RUN_FIRST, None, (str,)),
+    }
+
+    def __init__(
+        self,
+        *,
+        rows: list[tuple[str, ...]],
+        columns: list[str],
+        print_column: int = 1,
+        min_chars: int = 2,
+        placeholder: str = "Type to filter",
+        apply_label: str = "Apply",
+        on_apply=None,
+    ):
+        super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        self.set_margin_top(12)
+        self.set_margin_bottom(12)
+        self.set_margin_start(18)
+        self.set_margin_end(18)
+        self._ncols = len(columns)
+        self._print_idx = max(0, min(print_column - 1, self._ncols - 1))
+        self._min_chars = min_chars
+        self._on_apply = on_apply
+
+        # Search entry styled like Adw.EntryRow inside a single PreferencesGroup
+        entry_group = Adw.PreferencesGroup()
+        self.entry = Adw.EntryRow()
+        self.entry.set_title(placeholder)
+        entry_group.add(self.entry)
+        self.append(entry_group)
+
+        # Data + filter
+        self._store = Gio.ListStore.new(_Row)
+        for r in rows:
+            padded = tuple(list(r) + [""] * (self._ncols - len(r)))
+            self._store.append(_Row(padded))
+
+        self._filter = Gtk.CustomFilter.new()
+        self._filter.set_filter_func(self._filter_fn)
+        self._filter_model = Gtk.FilterListModel.new(self._store, self._filter)
+
+        self._selection = Gtk.SingleSelection.new(self._filter_model)
+        self._selection.set_autoselect(False)
+        self._selection.set_can_unselect(False)
+
+        self._cv = Gtk.ColumnView.new(self._selection)
+        self._cv.set_show_column_separators(False)
+        self._cv.set_show_row_separators(False)
+        for i, name in enumerate(columns):
+            factory = Gtk.SignalListItemFactory.new()
+            factory.connect("setup", self._on_setup)
+            factory.connect("bind", self._on_bind, i)
+            col = Gtk.ColumnViewColumn.new(name or "", factory)
+            col.set_expand(i == 0 or self._ncols == 1)
+            col.set_resizable(True)
+            self._cv.append_column(col)
+
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_hexpand(True)
+        scrolled.set_vexpand(True)
+        scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scrolled.set_child(self._cv)
+        scrolled.set_has_frame(True)
+        scrolled.add_css_class("card")
+        self.append(scrolled)
+
+        # Bottom action row
+        action_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        action_row.set_halign(Gtk.Align.END)
+        self._apply_btn = Gtk.Button(label=apply_label)
+        self._apply_btn.add_css_class("suggested-action")
+        self._apply_btn.connect("clicked", lambda _b: self._do_apply())
+        action_row.append(self._apply_btn)
+        self.append(action_row)
+
+        # Wiring
+        self.entry.connect("changed", self._on_changed)
+        self.entry.connect("entry-activated", lambda _e: self._do_apply())
+        self._cv.connect("activate", lambda *_a: self._do_apply())
+
+    def _filter_fn(self, item: _Row) -> bool:
+        q = self.entry.get_text().lower()
+        if len(q) < self._min_chars:
+            return self._min_chars == 0
+        return q in item._haystack
+
+    def _on_setup(self, _f, item):
+        lbl = Gtk.Label(xalign=0)
+        lbl.set_ellipsize(Pango.EllipsizeMode.END)
+        lbl.set_margin_start(6)
+        lbl.set_margin_end(6)
+        lbl.set_margin_top(4)
+        lbl.set_margin_bottom(4)
+        item.set_child(lbl)
+
+    def _on_bind(self, _f, item, idx: int):
+        item.get_child().set_text(item.get_item().values[idx] if idx < len(item.get_item().values) else "")
+
+    def _on_changed(self, _e):
+        self._filter.changed(Gtk.FilterChange.DIFFERENT)
+        if self._filter_model.get_n_items() > 0:
+            self._selection.set_selected(0)
+
+    def _do_apply(self) -> None:
+        idx = self._selection.get_selected()
+        if idx == Gtk.INVALID_LIST_POSITION:
+            return
+        item = self._filter_model.get_item(idx)
+        if item is None:
+            return
+        value = item.values[self._print_idx]
+        self.emit("applied", value)
+        if callable(self._on_apply):
+            self._on_apply(value)
+
+
+# ───────────────────────────────────────────────────────────────────────
+# CMS form panel.
+# ───────────────────────────────────────────────────────────────────────
+
+
+class CmsFormPanel(Gtk.Box):
+    """Three-row form for CMS URL / key / display name. Embeddable."""
+
+    __gsignals__ = {
+        "applied": (GObject.SignalFlags.RUN_FIRST, None, (str, str, str)),
+    }
+
+    def __init__(self, *, cms_url: str = "", cms_key: str = "", display_name: str = "", on_apply=None):
+        super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        self.set_margin_top(12)
+        self.set_margin_bottom(12)
+        self.set_margin_start(18)
+        self.set_margin_end(18)
+        self._on_apply = on_apply
+
+        group = Adw.PreferencesGroup()
+        self.url_row = Adw.EntryRow(title="CMS Server URL")
+        self.url_row.set_text(cms_url)
+        group.add(self.url_row)
+        self.key_row = Adw.PasswordEntryRow(title="CMS Key")
+        self.key_row.set_text(cms_key)
+        group.add(self.key_row)
+        self.name_row = Adw.EntryRow(title="Display Name")
+        self.name_row.set_text(display_name)
+        group.add(self.name_row)
+        self.append(group)
+
+        action_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        action_row.set_halign(Gtk.Align.END)
+        save_btn = Gtk.Button(label="Save")
+        save_btn.add_css_class("suggested-action")
+        save_btn.connect("clicked", lambda _b: self._do_apply())
+        action_row.append(save_btn)
+        self.append(action_row)
+
+    def _do_apply(self) -> None:
+        url = self.url_row.get_text().strip()
+        if url and not url.endswith("/"):
+            url += "/"
+        key = self.key_row.get_text().strip()
+        name = self.name_row.get_text().strip()
+        self.emit("applied", url, key, name)
+        if callable(self._on_apply):
+            self._on_apply(url, key, name)
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Player picker panel — radio rows.
+# ───────────────────────────────────────────────────────────────────────
+
+
+class PlayerPanel(Gtk.Box):
+    """Radio-row picker: Chromium / Electron."""
+
+    __gsignals__ = {
+        "applied": (GObject.SignalFlags.RUN_FIRST, None, (str,)),
+    }
+
+    def __init__(self, *, current: str = "Chromium", on_apply=None):
+        super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        self.set_margin_top(12)
+        self.set_margin_bottom(12)
+        self.set_margin_start(18)
+        self.set_margin_end(18)
+        self._on_apply = on_apply
+        self._checks: dict[str, Gtk.CheckButton] = {}
+
+        group = Adw.PreferencesGroup()
+        leader: Gtk.CheckButton | None = None
+        for label, subtitle in (
+            ("Chromium", "Chromium kiosk (default, lighter)"),
+            ("Electron", "Electron wrapper (heavier, more compatible)"),
+        ):
+            row = Adw.ActionRow(title=label, subtitle=subtitle)
+            check = Gtk.CheckButton()
+            if leader is None:
+                leader = check
+            else:
+                check.set_group(leader)
+            check.set_active(label == current)
+            row.add_prefix(check)
+            row.set_activatable_widget(check)
+            group.add(row)
+            self._checks[label] = check
+        self.append(group)
+
+        action_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        action_row.set_halign(Gtk.Align.END)
+        switch_btn = Gtk.Button(label="Switch")
+        switch_btn.add_css_class("suggested-action")
+        switch_btn.connect("clicked", lambda _b: self._do_apply())
+        action_row.append(switch_btn)
+        self.append(action_row)
+
+    def _do_apply(self) -> None:
+        for name, chk in self._checks.items():
+            if chk.get_active():
+                self.emit("applied", name)
+                if callable(self._on_apply):
+                    self._on_apply(name)
+                return
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Settings panel — actions list (Open terminal / GNOME Settings / Debug).
+# ───────────────────────────────────────────────────────────────────────
+
+
+class SettingsPanel(Gtk.Box):
+    """Sub-actions list: terminal / GNOME settings / debug bundle."""
+
+    __gsignals__ = {
+        "picked": (GObject.SignalFlags.RUN_FIRST, None, (str,)),
+    }
+
+    def __init__(self, *, on_pick=None):
+        super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        self.set_margin_top(12)
+        self.set_margin_bottom(12)
+        self.set_margin_start(18)
+        self.set_margin_end(18)
+        self._on_pick = on_pick
+
+        group = Adw.PreferencesGroup()
+        for action_id, title, subtitle in (
+            ("terminal", "Open terminal", "ptyxis (Ctrl+S also works)"),
+            ("gnome",    "GNOME Settings", "Advanced system tweaks"),
+            ("debug",    "Collect debug bundle", "~/Downloads/xibo-debug-*.tar.zst"),
+        ):
+            row = Adw.ActionRow(title=title, subtitle=subtitle)
+            row.set_activatable(True)
+            row._action_id = action_id  # type: ignore[attr-defined]
+            row.connect("activated", self._on_row_activated)
+            row.add_suffix(Gtk.Image.new_from_icon_name("go-next-symbolic"))
+            group.add(row)
+        self.append(group)
+
+    def _on_row_activated(self, row) -> None:
+        action = row._action_id  # type: ignore[attr-defined]
+        self.emit("picked", action)
+        if callable(self._on_pick):
+            self._on_pick(action)

--- a/kiosk/xiboplayer_kiosk/dialogs/picker.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/picker.py
@@ -1,0 +1,204 @@
+"""Picker — live-filter Gtk.ColumnView. Used for Language / Timezone /
+Keyboard / Wi-Fi / (Player uses a simpler radio-row variant)."""
+
+from __future__ import annotations
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+gi.require_version("Gdk", "4.0")
+from gi.repository import Adw, Gdk, Gio, GLib, GObject, Gtk, Pango  # noqa: E402
+
+from .base import BrandedAlertDialog
+
+
+class Row(GObject.Object):
+    """GObject wrapper so Gtk.FilterListModel accepts the items."""
+
+    __gtype_name__ = "XiboPickerRow"
+
+    def __init__(self, values: tuple[str, ...]):
+        super().__init__()
+        self.values = values
+        self._haystack = "\t".join(values).lower()
+
+
+_HEADER_HIDE_CSS = b"""
+columnview.hide-columnview-header > header {
+    opacity: 0;
+    min-height: 0;
+    padding: 0;
+}
+columnview.hide-columnview-header > header > * {
+    min-height: 0;
+    padding: 0;
+}
+"""
+_css_provider_installed = False
+
+
+def _install_css_once() -> None:
+    global _css_provider_installed
+    if _css_provider_installed:
+        return
+    p = Gtk.CssProvider()
+    p.load_from_data(_HEADER_HIDE_CSS)
+    Gtk.StyleContext.add_provider_for_display(
+        Gdk.Display.get_default(),
+        p,
+        Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
+    )
+    _css_provider_installed = True
+
+
+class Picker(BrandedAlertDialog):
+    """Filter-as-you-type picker.
+
+    Parameters
+    ----------
+    subtitle : str            — heading subtitle under the brand
+    body : str                — prompt text ("Type a locale code...")
+    rows : list[tuple[str,...]] — source data
+    columns : list[str]       — column headers (len = row tuple arity)
+    print_column : int        — 1-indexed column to return on confirm
+    min_chars : int           — filter engages at N chars (0 = show all)
+    hide_header : bool        — hide column-header row via CSS
+    placeholder : str         — search entry placeholder
+    """
+
+    def __init__(
+        self,
+        *,
+        subtitle: str,
+        body: str,
+        rows: list[tuple[str, ...]],
+        columns: list[str],
+        print_column: int = 1,
+        min_chars: int = 2,
+        hide_header: bool = False,
+        placeholder: str = "",
+    ):
+        super().__init__(heading_subtitle=subtitle, body=body)
+        self._rows = rows
+        self._ncols = len(columns)
+        self._print_idx = max(0, min(print_column - 1, self._ncols - 1))
+        self._min_chars = min_chars
+
+        extra = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        extra.set_size_request(520, 520)
+
+        self.entry = Gtk.SearchEntry()
+        self.entry.set_placeholder_text(
+            placeholder or (f"Type at least {min_chars} characters to filter" if min_chars > 0 else "Type to filter"),
+        )
+        extra.append(self.entry)
+
+        # Data model
+        self._store = Gio.ListStore.new(Row)
+        for r in rows:
+            padded = tuple(list(r) + [""] * (self._ncols - len(r)))
+            self._store.append(Row(padded))
+
+        self._filter = Gtk.CustomFilter.new()
+        self._filter.set_filter_func(self._filter_fn)
+        self._filter_model = Gtk.FilterListModel.new(self._store, self._filter)
+
+        self._selection = Gtk.SingleSelection.new(self._filter_model)
+        self._selection.set_autoselect(False)
+        self._selection.set_can_unselect(False)
+
+        self._cv = Gtk.ColumnView.new(self._selection)
+        self._cv.set_show_column_separators(False)
+        self._cv.set_show_row_separators(False)
+        self._cv.set_reorderable(False)
+
+        for i, name in enumerate(columns):
+            factory = Gtk.SignalListItemFactory.new()
+            factory.connect("setup", self._on_setup)
+            factory.connect("bind", self._on_bind, i)
+            col = Gtk.ColumnViewColumn.new(name or "", factory)
+            col.set_expand(i == 0 or self._ncols == 1)
+            col.set_resizable(True)
+            self._cv.append_column(col)
+
+        if hide_header or self._ncols == 1:
+            _install_css_once()
+            self._cv.add_css_class("hide-columnview-header")
+
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_hexpand(True)
+        scrolled.set_vexpand(True)
+        scrolled.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        scrolled.set_child(self._cv)
+        scrolled.set_has_frame(True)
+        extra.append(scrolled)
+
+        self.set_extra_child(extra)
+
+        self.add_cancel()
+        self.add_suggested("ok", "OK")
+
+        # Wire filter-as-you-type
+        self.entry.connect("search-changed", self._on_search_changed)
+        self.entry.connect("activate", self._on_entry_activate)
+        self._cv.connect("activate", lambda *a: self.response("ok"))
+
+        # Key: Down in entry → focus list, Escape → cancel
+        key_ctl = Gtk.EventControllerKey.new()
+        key_ctl.connect("key-pressed", self._on_key)
+        self.add_controller(key_ctl)
+
+        self.focus_after_present(self.entry)
+
+    def _filter_fn(self, item: Row) -> bool:
+        q = self.entry.get_text().lower()
+        if len(q) < self._min_chars:
+            return self._min_chars == 0
+        return q in item._haystack
+
+    def _on_setup(self, _factory, item):
+        lbl = Gtk.Label(xalign=0)
+        lbl.set_ellipsize(Pango.EllipsizeMode.END)
+        lbl.set_margin_start(6)
+        lbl.set_margin_end(6)
+        lbl.set_margin_top(4)
+        lbl.set_margin_bottom(4)
+        item.set_child(lbl)
+
+    def _on_bind(self, _factory, item, col_idx: int):
+        lbl = item.get_child()
+        row = item.get_item()
+        lbl.set_text(row.values[col_idx] if col_idx < len(row.values) else "")
+
+    def _auto_select_first(self) -> None:
+        if self._filter_model.get_n_items() > 0:
+            self._selection.set_selected(0)
+
+    def _on_search_changed(self, _e) -> None:
+        self._filter.changed(Gtk.FilterChange.DIFFERENT)
+        self._auto_select_first()
+
+    def _on_entry_activate(self, _e) -> None:
+        if self._selection.get_selected() == Gtk.INVALID_LIST_POSITION:
+            self._auto_select_first()
+        self.response("ok")
+
+    def _on_key(self, _ctl, keyval, _kc, _mods) -> bool:
+        if keyval == Gdk.KEY_Escape:
+            self.response("cancel")
+            return True
+        if keyval == Gdk.KEY_Down and self.entry.has_focus():
+            self._cv.grab_focus()
+            self._auto_select_first()
+            return True
+        return False
+
+    def selected_value(self) -> str | None:
+        idx = self._selection.get_selected()
+        if idx == Gtk.INVALID_LIST_POSITION:
+            return None
+        item = self._filter_model.get_item(idx)
+        if item is None:
+            return None
+        return item.values[self._print_idx]

--- a/kiosk/xiboplayer_kiosk/dialogs/picker.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/picker.py
@@ -138,16 +138,16 @@ class Picker(BrandedAlertDialog):
         scrolled.set_child(self._cv)
         scrolled.set_has_frame(False)
 
-        # Single-card visual grouping: entry on top, separator, scrolled
-        # list below. Each widget is parented ONCE — GTK4 raises if a
-        # widget is appended to two containers. Earlier version had a
-        # double-append bug that orphaned the entry.
-        card = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        card.add_css_class("card")
-        card.append(self.entry)
-        card.append(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
-        card.append(scrolled)
-        extra.append(card)
+        # Visual grouping via subtle separator only — NOT the `.card`
+        # CSS class, which paints its own dark background that clashes
+        # with the AlertDialog's lighter chrome (user reported
+        # "black-on-grey"). Leaving the entry + list transparent lets
+        # them inherit the dialog's background so they blend seamlessly.
+        group = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        group.append(self.entry)
+        group.append(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
+        group.append(scrolled)
+        extra.append(group)
 
         self.set_extra_child(extra)
 
@@ -157,7 +157,7 @@ class Picker(BrandedAlertDialog):
         # Wire filter-as-you-type
         self.entry.connect("search-changed", self._on_search_changed)
         self.entry.connect("activate", self._on_entry_activate)
-        self._cv.connect("activate", lambda *a: self.response("ok"))
+        self._cv.connect("activate", lambda *a: self.emit("response", "ok"))
 
         # Key: Down in entry → focus list, Escape → cancel
         key_ctl = Gtk.EventControllerKey.new()
@@ -197,11 +197,11 @@ class Picker(BrandedAlertDialog):
     def _on_entry_activate(self, _e) -> None:
         if self._selection.get_selected() == Gtk.INVALID_LIST_POSITION:
             self._auto_select_first()
-        self.response("ok")
+        self.emit("response", "ok")
 
     def _on_key(self, _ctl, keyval, _kc, _mods) -> bool:
         if keyval == Gdk.KEY_Escape:
-            self.response("cancel")
+            self.emit("response", "cancel")
             return True
         if keyval == Gdk.KEY_Down and self.entry.has_focus():
             self._cv.grab_focus()

--- a/kiosk/xiboplayer_kiosk/dialogs/picker.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/picker.py
@@ -91,13 +91,19 @@ class Picker(BrandedAlertDialog):
         self._print_idx = max(0, min(print_column - 1, self._ncols - 1))
         self._min_chars = min_chars
 
-        # Compact size — the list scrolls inside the card; no wasted margin.
-        extra = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
-        extra.set_size_request(440, 380)
+        # Compact size — the list scrolls below the entry; no wasted margin.
+        extra = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        extra.set_size_request(460, 420)
 
-        self.entry = Gtk.SearchEntry()
-        self.entry.set_placeholder_text(combined_placeholder)
-        self.entry.add_css_class("flat")  # no border — the card supplies it
+        # Adw.EntryRow gives the same visual style as the CmsForm fields
+        # (libadwaita preferences row: floating title, padded, large hit
+        # area, matching font/size). Wrap in a single-row PreferencesGroup
+        # so it gets the rounded boxed-list border.
+        entry_group = Adw.PreferencesGroup()
+        self.entry = Adw.EntryRow()
+        self.entry.set_title(combined_placeholder)
+        entry_group.add(self.entry)
+        extra.append(entry_group)
 
         # Data model
         self._store = Gio.ListStore.new(Row)
@@ -136,27 +142,23 @@ class Picker(BrandedAlertDialog):
         scrolled.set_vexpand(True)
         scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         scrolled.set_child(self._cv)
-        scrolled.set_has_frame(False)
-
-        # Visual grouping via subtle separator only — NOT the `.card`
-        # CSS class, which paints its own dark background that clashes
-        # with the AlertDialog's lighter chrome (user reported
-        # "black-on-grey"). Leaving the entry + list transparent lets
-        # them inherit the dialog's background so they blend seamlessly.
-        group = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        group.append(self.entry)
-        group.append(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
-        group.append(scrolled)
-        extra.append(group)
+        scrolled.set_has_frame(True)
+        # Match the EntryRow's rounded-border look so entry + list read
+        # as a vertically-stacked pair of cards (same idiom as
+        # PreferencesGroup → PreferencesGroup in GNOME Settings).
+        scrolled.add_css_class("card")
+        extra.append(scrolled)
 
         self.set_extra_child(extra)
 
         self.add_cancel()
         self.add_suggested("ok", "OK")
 
-        # Wire filter-as-you-type
-        self.entry.connect("search-changed", self._on_search_changed)
-        self.entry.connect("activate", self._on_entry_activate)
+        # Wire filter-as-you-type. Adw.EntryRow exposes Gtk.Editable's
+        # standard "changed" signal (not GtkSearchEntry's "search-changed").
+        # "entry-activated" is the libadwaita-specific Enter-press signal.
+        self.entry.connect("changed", self._on_search_changed)
+        self.entry.connect("entry-activated", self._on_entry_activate)
         self._cv.connect("activate", lambda *a: self.emit("response", "ok"))
 
         # Key: Down in entry → focus list, Escape → cancel

--- a/kiosk/xiboplayer_kiosk/dialogs/picker.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/picker.py
@@ -91,9 +91,10 @@ class Picker(BrandedAlertDialog):
         self._print_idx = max(0, min(print_column - 1, self._ncols - 1))
         self._min_chars = min_chars
 
-        # Compact size — the list scrolls below the entry; no wasted margin.
+        # Compact size — list has only as much room as it needs; the
+        # ScrolledWindow handles overflow. ~10 visible rows.
         extra = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
-        extra.set_size_request(460, 420)
+        extra.set_size_request(460, 300)
 
         # Adw.EntryRow gives the same visual style as the CmsForm fields
         # (libadwaita preferences row: floating title, padded, large hit
@@ -161,15 +162,23 @@ class Picker(BrandedAlertDialog):
         self.entry.connect("entry-activated", self._on_entry_activate)
         self._cv.connect("activate", lambda *a: self.emit("response", "ok"))
 
-        # Key controller: Escape → cancel, Down (in entry) → focus list.
-        # Use CAPTURE propagation so we see Escape BEFORE Adw.EntryRow's
-        # default handler consumes it to clear the entry text. Without
-        # capture, pressing Escape just empties the search field instead
-        # of closing the picker.
-        key_ctl = Gtk.EventControllerKey.new()
-        key_ctl.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
-        key_ctl.connect("key-pressed", self._on_key)
-        self.add_controller(key_ctl)
+        # Key controller — must be on the ENTRY (the focused widget),
+        # not the dialog. Adw.EntryRow's default key handler eats
+        # Escape to clear text; a dialog-level controller in any
+        # propagation phase doesn't run before the entry's own bound
+        # action, because Adw.EntryRow installs its Escape handler at
+        # the widget action level (not as an event controller). The
+        # only reliable way to override is to attach a CAPTURE-phase
+        # controller directly on the entry widget itself, which sees
+        # the keystroke before the entry's action class processes it.
+        ec_entry = Gtk.EventControllerKey.new()
+        ec_entry.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
+        ec_entry.connect("key-pressed", self._on_key)
+        self.entry.add_controller(ec_entry)
+        # Also at the dialog level for when focus moves to the list/buttons.
+        ec_dialog = Gtk.EventControllerKey.new()
+        ec_dialog.connect("key-pressed", self._on_key)
+        self.add_controller(ec_dialog)
 
         self.focus_after_present(self.entry)
 

--- a/kiosk/xiboplayer_kiosk/dialogs/picker.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/picker.py
@@ -79,19 +79,26 @@ class Picker(BrandedAlertDialog):
         hide_header: bool = False,
         placeholder: str = "",
     ):
-        super().__init__(heading_subtitle=subtitle, body=body)
+        # Body becomes the SearchEntry placeholder — folding the prompt
+        # into the entry kills the "disconnected prompt above entry"
+        # feel and lets the dialog shrink vertically.
+        combined_placeholder = placeholder or body or (
+            f"Type at least {min_chars} characters to filter" if min_chars > 0 else "Type to filter"
+        )
+        super().__init__(heading_subtitle=subtitle, body="")
         self._rows = rows
         self._ncols = len(columns)
         self._print_idx = max(0, min(print_column - 1, self._ncols - 1))
         self._min_chars = min_chars
 
-        extra = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
-        extra.set_size_request(520, 520)
+        # Tightened: smaller gap between entry and list, compact size.
+        extra = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
+        extra.set_size_request(480, 460)
 
         self.entry = Gtk.SearchEntry()
-        self.entry.set_placeholder_text(
-            placeholder or (f"Type at least {min_chars} characters to filter" if min_chars > 0 else "Type to filter"),
-        )
+        self.entry.set_placeholder_text(combined_placeholder)
+        # Visually flat search entry so it reads as "part of the list".
+        self.entry.add_css_class("flat")
         extra.append(self.entry)
 
         # Data model
@@ -129,10 +136,19 @@ class Picker(BrandedAlertDialog):
         scrolled = Gtk.ScrolledWindow()
         scrolled.set_hexpand(True)
         scrolled.set_vexpand(True)
-        scrolled.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         scrolled.set_child(self._cv)
-        scrolled.set_has_frame(True)
-        extra.append(scrolled)
+        scrolled.set_has_frame(False)
+        # Card container wraps both entry and list so they visually
+        # belong together — libadwaita's `card` CSS class gives a
+        # rounded border + subtle elevation.
+        card = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        card.add_css_class("card")
+        card.append(self.entry)
+        card.append(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
+        card.append(scrolled)
+        extra.remove(self.entry)  # move entry into the card (just added above)
+        extra.append(card)
 
         self.set_extra_child(extra)
 

--- a/kiosk/xiboplayer_kiosk/dialogs/picker.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/picker.py
@@ -161,8 +161,13 @@ class Picker(BrandedAlertDialog):
         self.entry.connect("entry-activated", self._on_entry_activate)
         self._cv.connect("activate", lambda *a: self.emit("response", "ok"))
 
-        # Key: Down in entry → focus list, Escape → cancel
+        # Key controller: Escape → cancel, Down (in entry) → focus list.
+        # Use CAPTURE propagation so we see Escape BEFORE Adw.EntryRow's
+        # default handler consumes it to clear the entry text. Without
+        # capture, pressing Escape just empties the search field instead
+        # of closing the picker.
         key_ctl = Gtk.EventControllerKey.new()
+        key_ctl.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
         key_ctl.connect("key-pressed", self._on_key)
         self.add_controller(key_ctl)
 

--- a/kiosk/xiboplayer_kiosk/dialogs/picker.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/picker.py
@@ -91,15 +91,13 @@ class Picker(BrandedAlertDialog):
         self._print_idx = max(0, min(print_column - 1, self._ncols - 1))
         self._min_chars = min_chars
 
-        # Tightened: smaller gap between entry and list, compact size.
-        extra = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
-        extra.set_size_request(480, 460)
+        # Compact size — the list scrolls inside the card; no wasted margin.
+        extra = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        extra.set_size_request(440, 380)
 
         self.entry = Gtk.SearchEntry()
         self.entry.set_placeholder_text(combined_placeholder)
-        # Visually flat search entry so it reads as "part of the list".
-        self.entry.add_css_class("flat")
-        extra.append(self.entry)
+        self.entry.add_css_class("flat")  # no border — the card supplies it
 
         # Data model
         self._store = Gio.ListStore.new(Row)
@@ -139,15 +137,16 @@ class Picker(BrandedAlertDialog):
         scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         scrolled.set_child(self._cv)
         scrolled.set_has_frame(False)
-        # Card container wraps both entry and list so they visually
-        # belong together — libadwaita's `card` CSS class gives a
-        # rounded border + subtle elevation.
+
+        # Single-card visual grouping: entry on top, separator, scrolled
+        # list below. Each widget is parented ONCE — GTK4 raises if a
+        # widget is appended to two containers. Earlier version had a
+        # double-append bug that orphaned the entry.
         card = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         card.add_css_class("card")
         card.append(self.entry)
         card.append(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
         card.append(scrolled)
-        extra.remove(self.entry)  # move entry into the card (just added above)
         extra.append(card)
 
         self.set_extra_child(extra)

--- a/kiosk/xiboplayer_kiosk/dialogs/player_picker.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/player_picker.py
@@ -1,0 +1,53 @@
+"""Player picker — 2-row radio selector (Chromium / Electron)."""
+
+from __future__ import annotations
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Adw, Gtk  # noqa: E402
+
+from .base import BrandedAlertDialog
+
+
+class PlayerPicker(BrandedAlertDialog):
+    def __init__(self, current: str = "Chromium"):
+        super().__init__(
+            heading_subtitle="Player",
+            body=f"Current player: {current} — choose which runs on next session.",
+        )
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        box.set_size_request(480, -1)
+
+        group = Adw.PreferencesGroup()
+        self._group_leader: Gtk.CheckButton | None = None
+        self._checks: dict[str, Gtk.CheckButton] = {}
+
+        for label, subtitle in (
+            ("Chromium", "Chromium kiosk (default, lighter)"),
+            ("Electron", "Electron wrapper (heavier, more compatible)"),
+        ):
+            row = Adw.ActionRow(title=label, subtitle=subtitle)
+            check = Gtk.CheckButton()
+            if self._group_leader is None:
+                self._group_leader = check
+            else:
+                check.set_group(self._group_leader)
+            check.set_active(label == current)
+            row.add_prefix(check)
+            row.set_activatable_widget(check)
+            group.add(row)
+            self._checks[label] = check
+
+        box.append(group)
+        self.set_extra_child(box)
+
+        self.add_cancel()
+        self.add_suggested("switch", "Switch")
+
+    def selected_player(self) -> str:
+        for name, chk in self._checks.items():
+            if chk.get_active():
+                return name
+        return "Chromium"

--- a/kiosk/xiboplayer_kiosk/dialogs/reconfigure_menu.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/reconfigure_menu.py
@@ -1,0 +1,46 @@
+"""Reconfigure menu — entered via Ctrl+R after first-boot is already done."""
+
+from __future__ import annotations
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Adw, Gtk  # noqa: E402
+
+from ..state import KioskState
+from .base import BrandedAlertDialog
+
+
+class ReconfigureMenu(BrandedAlertDialog):
+    def __init__(self, state: KioskState, *, on_pick=None):
+        super().__init__(
+            heading_subtitle="Reconfigure",
+            body=(f"Player:  {state.player}\nCMS:     {state.cms_url}"),
+        )
+        self.on_pick = on_pick
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        box.set_size_request(520, -1)
+
+        group = Adw.PreferencesGroup()
+        for action, title, subtitle in (
+            ("cms",    "Reconfigure CMS", "Edit CMS URL / key / display name"),
+            ("full",   "Full setup",      "Re-run the first-boot wizard"),
+            ("settings","Open Settings",  "Terminal / GNOME Settings / Debug bundle"),
+        ):
+            row = Adw.ActionRow(title=title, subtitle=subtitle)
+            row.set_activatable(True)
+            row.connect("activated", self._on_row_activated, action)
+            row.add_suffix(Gtk.Image.new_from_icon_name("go-next-symbolic"))
+            group.add(row)
+        box.append(group)
+
+        self.set_extra_child(box)
+
+        self.add_suggested("close", "Close")
+        self.set_close_response("close")
+
+    def _on_row_activated(self, _row, action: str) -> None:
+        if callable(self.on_pick):
+            self.on_pick(action)

--- a/kiosk/xiboplayer_kiosk/dialogs/settings_menu.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/settings_menu.py
@@ -1,0 +1,41 @@
+"""Settings sub-menu — Open terminal / GNOME Settings / Debug / Back."""
+
+from __future__ import annotations
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Adw, Gtk  # noqa: E402
+
+from .base import BrandedAlertDialog
+
+
+class SettingsMenu(BrandedAlertDialog):
+    def __init__(self, *, on_pick=None):
+        super().__init__(heading_subtitle="Settings", body="")
+        self.on_pick = on_pick
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        box.set_size_request(480, -1)
+
+        group = Adw.PreferencesGroup()
+        for action, title, subtitle in (
+            ("terminal", "Open terminal", "ptyxis (Ctrl+S also works)"),
+            ("gnome",    "GNOME Settings", "Advanced system tweaks (escape hatch)"),
+            ("debug",    "Collect debug bundle", "~/Downloads/xibo-debug-*.tar.zst"),
+        ):
+            row = Adw.ActionRow(title=title, subtitle=subtitle)
+            row.set_activatable(True)
+            row.connect("activated", self._on_row_activated, action)
+            row.add_suffix(Gtk.Image.new_from_icon_name("go-next-symbolic"))
+            group.add(row)
+        box.append(group)
+
+        self.set_extra_child(box)
+        self.add_suggested("back", "Back")
+        self.set_close_response("back")
+
+    def _on_row_activated(self, _row, action: str) -> None:
+        if callable(self.on_pick):
+            self.on_pick(action)

--- a/kiosk/xiboplayer_kiosk/dialogs/welcome.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/welcome.py
@@ -1,0 +1,74 @@
+"""Welcome splash — logo left, branded text right. First-boot only."""
+
+from __future__ import annotations
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Adw, Gtk  # noqa: E402
+
+from .. import branding
+from .base import BrandedAlertDialog
+
+
+class WelcomeSplash(BrandedAlertDialog):
+    """One-shot info prompt shown BEFORE the main menu on first boot."""
+
+    def __init__(self, version: str = "", build_date: str = ""):
+        super().__init__(heading_subtitle="", body="")
+        # Custom extra_child with logo LEFT + branded text RIGHT
+        self.set_heading("")  # use custom widget instead of heading
+
+        root = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        root.set_size_request(520, -1)
+
+        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=16)
+        row.set_halign(Gtk.Align.CENTER)
+        row.set_margin_top(4)
+        row.set_margin_bottom(4)
+
+        if branding.LOGO_PATH.exists():
+            img = Gtk.Image.new_from_file(str(branding.LOGO_PATH))
+            img.set_pixel_size(96)
+            img.set_valign(Gtk.Align.CENTER)
+            row.append(img)
+
+        text_col = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
+        text_col.set_hexpand(True)
+        text_col.set_valign(Gtk.Align.CENTER)
+
+        brand = Gtk.Label()
+        brand.set_markup(branding.BRAND_HEADING_MARKUP)
+        brand.set_xalign(0)
+        text_col.append(brand)
+
+        if version or build_date:
+            sub = Gtk.Label()
+            sub.set_markup(
+                f'<span size="medium">Welcome — v{version}'
+                + (f" ({build_date})" if build_date else "")
+                + "</span>",
+            )
+            sub.set_xalign(0)
+            sub.set_wrap(True)
+            text_col.append(sub)
+
+        row.append(text_col)
+        root.append(row)
+
+        body = Gtk.Label()
+        body.set_markup(
+            "The next screen lets you configure Language, Keyboard, Wi-Fi, "
+            "Timezone, Player, and CMS connection. Advanced and diagnostic "
+            "actions live under the Settings row. Press Continue when ready.",
+        )
+        body.set_xalign(0)
+        body.set_wrap(True)
+        body.set_margin_top(8)
+        root.append(body)
+
+        self.set_extra_child(root)
+
+        self.add_suggested("continue", "Continue")
+        self.add_cancel("Skip")

--- a/kiosk/xiboplayer_kiosk/dialogs/wifi_password.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/wifi_password.py
@@ -1,0 +1,35 @@
+"""Wi-Fi password dialog — single password entry with reveal eye."""
+
+from __future__ import annotations
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Adw, Gtk  # noqa: E402
+
+from .base import BrandedAlertDialog
+
+
+class WifiPasswordDialog(BrandedAlertDialog):
+    def __init__(self, ssid: str):
+        super().__init__(
+            heading_subtitle="Wi-Fi password",
+            body=f"Enter password for {ssid}",
+        )
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        box.set_size_request(440, -1)
+        group = Adw.PreferencesGroup()
+        self.pw = Adw.PasswordEntryRow(title="Password")
+        group.add(self.pw)
+        box.append(group)
+        self.set_extra_child(box)
+
+        self.add_cancel()
+        self.add_suggested("connect", "Connect")
+
+        self.focus_after_present(self.pw)
+
+    @property
+    def password(self) -> str:
+        return self.pw.get_text()

--- a/kiosk/xiboplayer_kiosk/dialogs/window.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/window.py
@@ -134,27 +134,49 @@ class KioskWindow(Adw.ApplicationWindow):
         return page
 
     def _build_content_placeholder(self) -> Adw.NavigationPage:
-        """Initial right-pane content. Replaced on the first sidebar click."""
+        """Initial right-pane content. Replaced on the first sidebar click.
+
+        Uses a tight custom layout instead of Adw.StatusPage because the
+        latter vertically centers content with large padding — that
+        looked like "wasted middle space". This version pins the logo +
+        text near the top with compact spacing.
+        """
         toolbar = Adw.ToolbarView()
         toolbar.add_top_bar(Adw.HeaderBar())
-        status = Adw.StatusPage()
-        # Use the xiboplayer logo as the status-page icon. Adw.StatusPage's
-        # `paintable` property accepts any Gdk.Paintable; Gdk.Texture
-        # loads a file straight off disk into a paintable. Falls back to
-        # a generic icon if the logo is missing (e.g. uninstalled dev runs).
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        box.set_margin_top(36)
+        box.set_margin_bottom(24)
+        box.set_margin_start(24)
+        box.set_margin_end(24)
+        box.set_halign(Gtk.Align.CENTER)
+        box.set_valign(Gtk.Align.START)
+
         if branding.LOGO_PATH.exists():
             try:
-                status.set_paintable(Gdk.Texture.new_from_filename(str(branding.LOGO_PATH)))
+                pic = Gtk.Picture.new_for_filename(str(branding.LOGO_PATH))
+                pic.set_size_request(160, 160)
+                pic.set_can_shrink(True)
+                pic.set_content_fit(Gtk.ContentFit.CONTAIN)
+                box.append(pic)
             except Exception:  # noqa: BLE001
-                status.set_icon_name("preferences-system-symbolic")
-        else:
-            status.set_icon_name("preferences-system-symbolic")
-        status.set_title("xiboplayer first boot")
-        status.set_description(
-            "Select a category from the left to configure it.\n"
-            "Press Start player when ready.",
+                pass
+
+        title = Gtk.Label()
+        title.set_markup('<span size="x-large" weight="bold">xiboplayer first boot</span>')
+        title.set_xalign(0.5)
+        box.append(title)
+
+        desc = Gtk.Label(
+            label="Select a category from the left to configure it.\n"
+                  "Press Start player when ready.",
         )
-        toolbar.set_content(status)
+        desc.set_justify(Gtk.Justification.CENTER)
+        desc.set_xalign(0.5)
+        desc.add_css_class("dim-label")
+        box.append(desc)
+
+        toolbar.set_content(box)
         page = Adw.NavigationPage()
         page.set_title("xiboplayer")
         page.set_child(toolbar)

--- a/kiosk/xiboplayer_kiosk/dialogs/window.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/window.py
@@ -20,7 +20,8 @@ import gi
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
-from gi.repository import Adw, Gtk  # noqa: E402
+gi.require_version("Gdk", "4.0")
+from gi.repository import Adw, Gdk, Gtk  # noqa: E402
 
 from .. import branding
 
@@ -137,7 +138,17 @@ class KioskWindow(Adw.ApplicationWindow):
         toolbar = Adw.ToolbarView()
         toolbar.add_top_bar(Adw.HeaderBar())
         status = Adw.StatusPage()
-        status.set_icon_name("preferences-system-symbolic")
+        # Use the xiboplayer logo as the status-page icon. Adw.StatusPage's
+        # `paintable` property accepts any Gdk.Paintable; Gdk.Texture
+        # loads a file straight off disk into a paintable. Falls back to
+        # a generic icon if the logo is missing (e.g. uninstalled dev runs).
+        if branding.LOGO_PATH.exists():
+            try:
+                status.set_paintable(Gdk.Texture.new_from_filename(str(branding.LOGO_PATH)))
+            except Exception:  # noqa: BLE001
+                status.set_icon_name("preferences-system-symbolic")
+        else:
+            status.set_icon_name("preferences-system-symbolic")
         status.set_title("xiboplayer first boot")
         status.set_description(
             "Select a category from the left to configure it.\n"

--- a/kiosk/xiboplayer_kiosk/dialogs/window.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/window.py
@@ -1,0 +1,189 @@
+"""KioskWindow — single window with sidebar + content (Adw.NavigationSplitView).
+
+Replaces the dialog-per-screen flow with a GNOME Settings / Control Center
+style layout: persistent sidebar on the left listing categories (Language,
+Keyboard, Wi-Fi, Timezone, Player, CMS), with the selected category's UI
+rendered inline in the content pane on the right. No new windows for
+sub-screens — the user navigates by clicking sidebar rows, no back-stack
+popups, no dialog churn.
+
+Sub-screens (Picker, CmsForm, PlayerPicker) are reused as **embedded
+widgets**, swapped into the content area's child slot. They keep the same
+visual style — Adw.PreferencesGroup + Adw.EntryRow — but no AlertDialog
+wrapper, no OK/Cancel chrome (sidebar handles navigation; each panel has
+its own action area).
+"""
+
+from __future__ import annotations
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Adw, Gtk  # noqa: E402
+
+from .. import branding
+
+
+_CATEGORIES = [
+    ("language", "Language"),
+    ("keyboard", "Keyboard"),
+    ("wifi",     "Wi-Fi"),
+    ("timezone", "Timezone"),
+    ("player",   "Player"),
+    ("cms",      "CMS"),
+    ("settings", "Settings"),
+]
+
+
+class KioskWindow(Adw.ApplicationWindow):
+    """Top-level window. Holds the split view + handles category selection.
+
+    Parameters
+    ----------
+    app
+        The Adw.Application this window belongs to. Used for lifecycle
+        (app.release() when the user clicks "Start player" or closes).
+    state
+        Shared KioskState used to render sidebar status subtitles AND
+        passed to whatever panel is currently shown.
+    on_pick
+        Callable taking ``(category_id: str)`` invoked when the user
+        clicks a sidebar row. Implementor swaps the content panel.
+    on_start
+        Callable invoked when the user clicks the "Start player" button
+        in the header. Caller normally calls app.release() here.
+    version
+        Version string for the sidebar title subtitle.
+    """
+
+    def __init__(self, app, state, *, on_pick=None, on_start=None, version: str = ""):
+        super().__init__(application=app)
+        self.state = state
+        self.on_pick = on_pick
+        self.on_start = on_start
+        self.set_title("xiboplayer")
+        self.set_default_size(820, 520)
+
+        self._split = Adw.NavigationSplitView()
+        self._split.set_min_sidebar_width(240)
+        self._split.set_max_sidebar_width(280)
+        self._split.set_sidebar_width_fraction(0.35)
+
+        self._sidebar_page = self._build_sidebar(version)
+        self._content_page = self._build_content_placeholder()
+        self._split.set_sidebar(self._sidebar_page)
+        self._split.set_content(self._content_page)
+
+        self.set_content(self._split)
+
+    # ── sidebar ─────────────────────────────────────────────────────────
+
+    def _build_sidebar(self, version: str) -> Adw.NavigationPage:
+        """One Adw.NavigationPage hosting a HeaderBar + ListBox of categories."""
+        toolbar = Adw.ToolbarView()
+
+        header = Adw.HeaderBar()
+        title_widget = Gtk.Label()
+        title_widget.set_markup(branding.BRAND_HEADING_MARKUP)
+        title_widget.set_use_markup(True)
+        header.set_title_widget(title_widget)
+        toolbar.add_top_bar(header)
+
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_hexpand(True)
+        scrolled.set_vexpand(True)
+        scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+
+        self._listbox = Gtk.ListBox()
+        self._listbox.add_css_class("navigation-sidebar")
+        self._listbox.set_selection_mode(Gtk.SelectionMode.SINGLE)
+        self._listbox.connect("row-activated", self._on_sidebar_row_activated)
+        self._sidebar_rows: dict[str, Adw.ActionRow] = {}
+        for category_id, title in _CATEGORIES:
+            row = Adw.ActionRow(title=title)
+            row.set_subtitle(self._sidebar_subtitle(category_id))
+            row.set_activatable(True)
+            row._category_id = category_id  # type: ignore[attr-defined]
+            self._listbox.append(row)
+            self._sidebar_rows[category_id] = row
+        scrolled.set_child(self._listbox)
+
+        # "Start player" goes at the BOTTOM of the sidebar — always
+        # reachable, can't be lost in a sub-page.
+        bottom_bar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        bottom_bar.set_margin_top(6)
+        bottom_bar.set_margin_bottom(8)
+        bottom_bar.set_margin_start(8)
+        bottom_bar.set_margin_end(8)
+        start_btn = Gtk.Button(label="Start player")
+        start_btn.add_css_class("suggested-action")
+        start_btn.set_hexpand(True)
+        start_btn.connect("clicked", lambda _b: self.on_start() if callable(self.on_start) else None)
+        bottom_bar.append(start_btn)
+
+        sidebar_root = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        sidebar_root.append(scrolled)
+        sidebar_root.append(bottom_bar)
+        toolbar.set_content(sidebar_root)
+
+        page = Adw.NavigationPage()
+        page.set_title("xiboplayer")
+        page.set_child(toolbar)
+        return page
+
+    def _build_content_placeholder(self) -> Adw.NavigationPage:
+        """Initial right-pane content. Replaced on the first sidebar click."""
+        toolbar = Adw.ToolbarView()
+        toolbar.add_top_bar(Adw.HeaderBar())
+        status = Adw.StatusPage()
+        status.set_icon_name("preferences-system-symbolic")
+        status.set_title("xiboplayer first boot")
+        status.set_description(
+            "Select a category from the left to configure it.\n"
+            "Press Start player when ready.",
+        )
+        toolbar.set_content(status)
+        page = Adw.NavigationPage()
+        page.set_title("xiboplayer")
+        page.set_child(toolbar)
+        return page
+
+    # ── public API for the controller ───────────────────────────────────
+
+    def set_content_panel(self, title: str, widget: Gtk.Widget) -> None:
+        """Replace the right-pane content with `widget` under `title`."""
+        toolbar = Adw.ToolbarView()
+        header = Adw.HeaderBar()
+        header.set_title_widget(Adw.WindowTitle.new(title, ""))
+        toolbar.add_top_bar(header)
+        toolbar.set_content(widget)
+        page = Adw.NavigationPage()
+        page.set_title(title)
+        page.set_child(toolbar)
+        self._split.set_content(page)
+        self._content_page = page
+
+    def refresh_sidebar(self) -> None:
+        """Re-render every sidebar row's status subtitle from KioskState."""
+        self.state.refresh_all()
+        for category_id, row in self._sidebar_rows.items():
+            row.set_subtitle(self._sidebar_subtitle(category_id))
+
+    # ── private helpers ─────────────────────────────────────────────────
+
+    def _sidebar_subtitle(self, category_id: str) -> str:
+        s = self.state
+        return {
+            "language": s.locale or "(unknown)",
+            "keyboard": s.keyboard_layout,
+            "wifi":     s.wifi_ssid,
+            "timezone": s.timezone,
+            "player":   s.player,
+            "cms":      s.cms_url,
+            "settings": "Terminal · GNOME Settings · Debug",
+        }.get(category_id, "")
+
+    def _on_sidebar_row_activated(self, _box, row) -> None:
+        if callable(self.on_pick):
+            self.on_pick(row._category_id)  # type: ignore[attr-defined]

--- a/kiosk/xiboplayer_kiosk/doas_runner.py
+++ b/kiosk/xiboplayer_kiosk/doas_runner.py
@@ -1,0 +1,85 @@
+"""DoasRunner — single choke-point for calls to the xibo-set-*.sh helpers.
+
+Every mutator (wifi connect, timezone set, locale set, keyboard set, player
+switch) goes through doas to the corresponding shell helper. This wrapper:
+- Captures stderr (today's scripts redirect to /dev/null → silent failures)
+- Has a timeout (unresponsive nmcli won't freeze the UI forever)
+- Never raises — returns (bool, str) so the caller can show ErrorDialog
+
+The boundary: Python never uses sudo/doas on its own commands. Only the
+shell helpers can be elevated — they validate arguments and are allowlisted
+in /etc/doas.conf.
+"""
+
+import subprocess
+from pathlib import Path
+
+
+class DoasRunner:
+    """Runs the privileged `xibo-set-*.sh` helpers via `doas`.
+
+    The kiosk wizard is a user-level application, but mutating system
+    state (WiFi keyfile, timezone, locale, keyboard layout, player
+    alternative) requires root. Rather than giving the Python app any
+    elevation, we call pre-validated shell helpers that are allowlisted
+    in `/etc/doas.conf` for the xibo user.
+
+    This class centralises the `doas <kiosk_dir>/xibo-set-*.sh ARG...`
+    invocation so every mutation goes through the same code path and
+    we can (a) capture stderr (shell scripts historically `2>/dev/null`
+    their errors, leading to silent failures), (b) enforce a timeout
+    (unresponsive `nmcli` must not freeze the UI indefinitely), and (c)
+    never raise — errors come back as `(False, message)` so callers can
+    surface them in an `ErrorDialog`.
+    """
+
+    def __init__(self, kiosk_dir: Path = Path("/usr/share/xiboplayer-kiosk")):
+        """
+        Parameters
+        ----------
+        kiosk_dir
+            Directory that contains the `xibo-set-*.sh` helper scripts.
+            Injectable for tests; defaults to the on-disk install path.
+        """
+        self.kiosk_dir = kiosk_dir
+
+    def run(self, helper: str, *args: str, timeout: int = 30) -> tuple[bool, str]:
+        """Invoke a single `xibo-set-*.sh` helper via `doas`.
+
+        Parameters
+        ----------
+        helper
+            Basename of the helper script, e.g. ``"xibo-set-timezone.sh"``.
+            Joined with ``kiosk_dir`` to form the absolute path.
+        *args
+            Positional arguments forwarded to the helper (already validated
+            by the shell script's own argument parser).
+        timeout
+            Kill the subprocess if it runs longer than this many seconds.
+
+        Returns
+        -------
+        tuple[bool, str]
+            ``(True, combined_output)`` on exit-code 0; otherwise
+            ``(False, message)`` where *message* contains captured stderr
+            and stdout (suitable for display in an error dialog).
+
+        Notes
+        -----
+        Never raises — all exception classes are mapped to a
+        ``(False, message)`` return so calling code can stay branch-free.
+        """
+        script = self.kiosk_dir / helper
+        cmd = ["doas", str(script), *args]
+        try:
+            r = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=timeout, check=False,
+            )
+            combined = (r.stderr or "") + (r.stdout or "")
+            return r.returncode == 0, combined
+        except subprocess.TimeoutExpired:
+            return False, f"{helper} timed out after {timeout}s"
+        except FileNotFoundError:
+            return False, f"{helper} not found at {script}"
+        except Exception as e:  # noqa: BLE001 — caller surfaces to UI
+            return False, f"{helper} failed: {e}"

--- a/kiosk/xiboplayer_kiosk/preseed.py
+++ b/kiosk/xiboplayer_kiosk/preseed.py
@@ -1,0 +1,81 @@
+"""Pure-Python port of _preseed_get from kickstart %post.
+
+/etc/xiboplayer-preseed.env is a KEY=VALUE file written by the installer
+%post from kernel-cmdline `xibo.*=` params + `xibo.config_url=` JSON
+fetch + USB /setup.json auto-detect. We NEVER `source` it (shell-eval
+would let a malicious value run arbitrary code); we parse KEY=VALUE
+lines explicitly.
+"""
+
+from pathlib import Path
+
+PRESEED_PATH = Path("/etc/xiboplayer-preseed.env")
+
+
+def read(key: str, path: Path | None = None) -> str:
+    """Look up a single key in the preseed environment file.
+
+    Parameters
+    ----------
+    key
+        Full dotted key name, e.g. ``"xibo.cms_url"``.
+    path
+        File to read. Defaults to ``/etc/xiboplayer-preseed.env`` but is
+        injectable for tests.
+
+    Returns
+    -------
+    str
+        The value string with surrounding whitespace stripped, or ``""``
+        if the key is absent, the file is missing, or an I/O error occurs.
+
+    Notes
+    -----
+    We never ``source`` the preseed file. Shell evaluation would let a
+    malicious value run arbitrary commands (e.g. via ``xibo.cms_url=$(rm -rf /)``).
+    Parsing each line as ``KEY=VALUE`` is safe against every form of
+    shell injection.
+    """
+    if path is None:
+        path = PRESEED_PATH
+    try:
+        with path.open() as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith(key + "="):
+                    return line[len(key) + 1:]
+    except FileNotFoundError:
+        pass
+    return ""
+
+
+def read_all(path: Path | None = None) -> dict[str, str]:
+    """Parse every ``KEY=VALUE`` line from the preseed file.
+
+    Parameters
+    ----------
+    path
+        File to read. Defaults to ``/etc/xiboplayer-preseed.env``.
+
+    Returns
+    -------
+    dict[str, str]
+        Mapping of key names to values. Blank lines and lines starting
+        with ``#`` are skipped. Empty dict if file missing.
+    """
+    if path is None:
+        path = PRESEED_PATH
+    out: dict[str, str] = {}
+    try:
+        with path.open() as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if "=" not in line:
+                    continue
+                k, _, v = line.partition("=")
+                out[k] = v
+    except FileNotFoundError:
+        pass
+    return out

--- a/kiosk/xiboplayer_kiosk/services/__init__.py
+++ b/kiosk/xiboplayer_kiosk/services/__init__.py
@@ -1,0 +1,5 @@
+"""Per-domain read/write service modules.
+
+Each module exposes `list_*()` read functions (no doas needed) and `set_*(state, doas, ...)`
+mutators that call DoasRunner and then update KioskState.
+"""

--- a/kiosk/xiboplayer_kiosk/services/cms.py
+++ b/kiosk/xiboplayer_kiosk/services/cms.py
@@ -1,0 +1,79 @@
+"""CMS config writers — port of zlib_write_*_config from xibo-zenity-lib.sh.
+
+One function per player. Called after CmsForm dialog collects URL/key/name.
+Writes to the player-specific config file; NO doas needed (we write into
+$HOME/.config/xiboplayer/<player>/config.json owned by the xibo user).
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+from pathlib import Path
+
+
+def _ensure_slash(url: str) -> str:
+    return url if url.endswith("/") else url + "/"
+
+
+def write_chromium(config_dir: Path, url: str, key: str, display_name: str) -> None:
+    d = config_dir / "chromium"
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / "config.json"
+    data: dict = {}
+    if path.exists():
+        try:
+            data = json.loads(path.read_text())
+        except json.JSONDecodeError:
+            data = {}
+    data["cmsUrl"] = _ensure_slash(url)
+    data["cmsKey"] = key
+    if display_name:
+        data["displayName"] = display_name
+    path.write_text(json.dumps(data, indent=2))
+
+
+def write_electron(config_dir: Path, url: str, key: str, display_name: str) -> None:
+    d = config_dir / "electron"
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / "config.json"
+    data: dict = {}
+    if path.exists():
+        try:
+            data = json.loads(path.read_text())
+        except json.JSONDecodeError:
+            data = {}
+    data["cmsUrl"] = _ensure_slash(url)
+    data["cmsKey"] = key
+    if display_name:
+        data["displayName"] = display_name
+    path.write_text(json.dumps(data, indent=2))
+
+
+def write_arexibo(data_dir: Path, url: str, key: str, display_name: str) -> None:
+    """Arexibo uses ~/.local/share/xibo/cms.json with a different schema."""
+    data_dir.mkdir(parents=True, exist_ok=True)
+    hw_key = "xibo-" + secrets.token_hex(6)
+    (data_dir / "cms.json").write_text(json.dumps({
+        "address": _ensure_slash(url),
+        "key": key,
+        "displayId": hw_key,
+        "displayName": display_name or hw_key,
+    }, indent=2))
+
+
+def write_for_player(
+    player: str,
+    config_dir: Path,
+    data_dir: Path,
+    url: str,
+    key: str,
+    display_name: str,
+) -> None:
+    """Dispatch on current player. Falls back to Chromium."""
+    if player == "Electron":
+        write_electron(config_dir, url, key, display_name)
+    elif player == "Arexibo":
+        write_arexibo(data_dir, url, key, display_name)
+    else:
+        write_chromium(config_dir, url, key, display_name)

--- a/kiosk/xiboplayer_kiosk/services/keyboard.py
+++ b/kiosk/xiboplayer_kiosk/services/keyboard.py
@@ -1,0 +1,16 @@
+"""Keyboard-layout list. Reads from `localectl list-x11-keymap-layouts`."""
+
+import subprocess
+
+
+def list_layouts() -> list[str]:
+    try:
+        r = subprocess.run(
+            ["localectl", "list-x11-keymap-layouts"],
+            capture_output=True, text=True, timeout=5, check=False,
+        )
+    except Exception:  # noqa: BLE001
+        return []
+    if r.returncode != 0:
+        return []
+    return [line.strip() for line in r.stdout.splitlines() if line.strip()]

--- a/kiosk/xiboplayer_kiosk/services/locale.py
+++ b/kiosk/xiboplayer_kiosk/services/locale.py
@@ -1,0 +1,32 @@
+"""Locale read + set. Filter list matches kickstart/xibo-first-boot.sh."""
+
+import re
+import subprocess
+
+
+# Same filter as kiosk/xibo-first-boot.sh handle_language:
+# drop @variant, non-UTF-8 encodings, C.*, POSIX
+_REJECT = re.compile(r"@|\.(iso|ISO|koi|KOI|gb|GB|euc|EUC|big|BIG)")
+
+
+def list_locales() -> list[str]:
+    """All UTF-8 locales from localectl list-locales, sans @variants + legacy encodings."""
+    try:
+        r = subprocess.run(
+            ["localectl", "list-locales"], capture_output=True, text=True, timeout=5, check=False,
+        )
+    except Exception:  # noqa: BLE001
+        return []
+    if r.returncode != 0:
+        return []
+    out: list[str] = []
+    for line in r.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if _REJECT.search(line):
+            continue
+        if line.startswith("C.") or line == "POSIX":
+            continue
+        out.append(line)
+    return out

--- a/kiosk/xiboplayer_kiosk/services/notify.py
+++ b/kiosk/xiboplayer_kiosk/services/notify.py
@@ -1,0 +1,13 @@
+"""Desktop notifications — thin wrapper around notify-send."""
+
+import subprocess
+
+
+def send(msg: str, urgency: str = "normal", replace_id: int = 1) -> None:
+    try:
+        subprocess.run(
+            ["notify-send", "-r", str(replace_id), "-u", urgency, "-t", "0", "Xibo", msg],
+            check=False, capture_output=True, timeout=5,
+        )
+    except Exception:  # noqa: BLE001
+        pass

--- a/kiosk/xiboplayer_kiosk/services/status.py
+++ b/kiosk/xiboplayer_kiosk/services/status.py
@@ -1,0 +1,95 @@
+"""Read-only status probes — never mutate, never call doas.
+
+Each function returns a string suitable for the main-menu status column.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+
+def _run(cmd: list[str]) -> str:
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=5, check=False)
+        return r.stdout.strip() if r.returncode == 0 else ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def wifi_status() -> str:
+    """Active Wi-Fi SSID, or '(wired)' / '(not connected)' / '(no wifi hardware)'."""
+    have_wifi = _run(["nmcli", "-t", "-f", "DEVICE,TYPE", "dev", "status"])
+    if "wifi" not in have_wifi:
+        return "(no wifi hardware)"
+    active = _run(["nmcli", "-t", "-f", "NAME,TYPE,STATE", "conn", "show", "--active"])
+    for line in active.splitlines():
+        parts = line.split(":")
+        if len(parts) >= 3 and parts[2] == "activated":
+            if parts[1] == "802-11-wireless":
+                return parts[0]
+            if parts[1] == "802-3-ethernet":
+                return "(wired)"
+    return "(not connected)"
+
+
+def timezone_status() -> str:
+    return _run(["timedatectl", "show", "-p", "Timezone", "--value"]) or "(unknown)"
+
+
+def locale_status() -> str:
+    """Value of /etc/locale.conf LANG, or 'C.UTF-8' if unset."""
+    try:
+        with Path("/etc/locale.conf").open() as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("LANG="):
+                    return line[5:].strip('"')
+    except FileNotFoundError:
+        pass
+    return _run(["localectl", "status"]).splitlines()[0] if _run(["localectl", "status"]) else "C.UTF-8"
+
+
+def keyboard_status() -> str:
+    """X11 keyboard layout (+variant) from localectl."""
+    out = _run(["localectl", "status"])
+    layout = variant = ""
+    for line in out.splitlines():
+        s = line.strip()
+        if s.startswith("X11 Layout:"):
+            layout = s.split(":", 1)[1].strip()
+        elif s.startswith("X11 Variant:"):
+            variant = s.split(":", 1)[1].strip()
+    if layout and variant:
+        return f"{layout} ({variant})"
+    return layout or "(unknown)"
+
+
+def player_status(config_dir: Path) -> tuple[str, str]:
+    """Return (player_label, service_name) from setup-result.json.
+
+    Fallback: Chromium (matches xibo.profile=chromium default).
+    """
+    path = config_dir / "setup-result.json"
+    try:
+        with path.open() as f:
+            data = json.load(f)
+        return data.get("player", "Chromium"), data.get("service", "xiboplayer-chromium.service")
+    except (FileNotFoundError, json.JSONDecodeError):
+        return "Chromium", "xiboplayer-chromium.service"
+
+
+def cms_status(config_dir: Path, data_dir: Path, player: str) -> str:
+    """Return the CMS URL for the active player, or '(not configured)'."""
+    if player == "Arexibo":
+        path = data_dir / "cms.json"
+    elif player == "Electron":
+        path = config_dir / "electron" / "config.json"
+    else:  # Chromium + any other
+        path = config_dir / "chromium" / "config.json"
+    try:
+        with path.open() as f:
+            data = json.load(f)
+        # chromium/electron use cmsUrl; arexibo uses address
+        return data.get("cmsUrl") or data.get("address") or "(not configured)"
+    except (FileNotFoundError, json.JSONDecodeError):
+        return "(not configured)"

--- a/kiosk/xiboplayer_kiosk/services/timezone.py
+++ b/kiosk/xiboplayer_kiosk/services/timezone.py
@@ -1,0 +1,16 @@
+"""Timezone list. Reads from `timedatectl list-timezones`."""
+
+import subprocess
+
+
+def list_timezones() -> list[str]:
+    try:
+        r = subprocess.run(
+            ["timedatectl", "list-timezones"],
+            capture_output=True, text=True, timeout=5, check=False,
+        )
+    except Exception:  # noqa: BLE001
+        return []
+    if r.returncode != 0:
+        return []
+    return [line.strip() for line in r.stdout.splitlines() if line.strip()]

--- a/kiosk/xiboplayer_kiosk/services/wifi.py
+++ b/kiosk/xiboplayer_kiosk/services/wifi.py
@@ -1,0 +1,90 @@
+"""Wi-Fi list + scan. Mutation via DoasRunner / xibo-set-wifi.sh."""
+
+import subprocess
+from dataclasses import dataclass
+
+
+@dataclass
+class WifiNetwork:
+    ssid: str
+    signal: int  # 0-100
+    security: str  # "open" | "WPA2" | "WPA3" | ...
+    in_use: bool
+
+
+def has_wifi_hardware() -> bool:
+    try:
+        r = subprocess.run(
+            ["nmcli", "-t", "-f", "DEVICE,TYPE", "dev", "status"],
+            capture_output=True, text=True, timeout=3, check=False,
+        )
+    except Exception:  # noqa: BLE001
+        return False
+    return any(":wifi" in line for line in r.stdout.splitlines())
+
+
+def rescan() -> None:
+    """Fire a WiFi rescan in the background; returns immediately."""
+    try:
+        subprocess.Popen(
+            ["nmcli", "dev", "wifi", "rescan"],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def list_networks() -> list[WifiNetwork]:
+    """Return currently-visible networks sorted by signal, deduped by SSID."""
+    try:
+        r = subprocess.run(
+            ["nmcli", "-t", "-f", "IN-USE,SSID,SIGNAL,SECURITY", "dev", "wifi", "list"],
+            capture_output=True, text=True, timeout=5, check=False,
+        )
+    except Exception:  # noqa: BLE001
+        return []
+    if r.returncode != 0:
+        return []
+    seen: dict[str, WifiNetwork] = {}
+    for line in r.stdout.splitlines():
+        # nmcli -t escapes embedded colons with a backslash. naïve split
+        # is fine for 4 fields where SSID is field 2 (rare edge: SSIDs
+        # containing colon — de-escape).
+        parts = _split_nmcli_line(line)
+        if len(parts) < 4:
+            continue
+        in_use, ssid, signal_s, security = parts[0], parts[1], parts[2], parts[3]
+        if not ssid or ssid in seen:
+            continue
+        try:
+            signal = int(signal_s)
+        except ValueError:
+            signal = 0
+        if not security or security == "--":
+            security = "open"
+        seen[ssid] = WifiNetwork(
+            ssid=ssid, signal=signal, security=security, in_use=(in_use == "*"),
+        )
+    return sorted(seen.values(), key=lambda n: (-n.signal, n.ssid))
+
+
+def _split_nmcli_line(line: str) -> list[str]:
+    """Split nmcli -t output: `:` separator with `\\:` escape."""
+    out: list[str] = []
+    buf = ""
+    i = 0
+    while i < len(line):
+        c = line[i]
+        if c == "\\" and i + 1 < len(line) and line[i + 1] == ":":
+            buf += ":"
+            i += 2
+            continue
+        if c == ":":
+            out.append(buf)
+            buf = ""
+            i += 1
+            continue
+        buf += c
+        i += 1
+    out.append(buf)
+    return out

--- a/kiosk/xiboplayer_kiosk/state.py
+++ b/kiosk/xiboplayer_kiosk/state.py
@@ -1,0 +1,66 @@
+"""KioskState — single source of truth for UI status.
+
+Loaded once at startup via KioskState.load(). Dialog refresh_* methods are
+called after each successful setter to keep the UI live without re-shelling
+on every paint.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from . import preseed
+from .services import status
+
+
+@dataclass
+class KioskState:
+    wifi_ssid: str = ""
+    wifi_hardware_present: bool = False
+    wired_connected: bool = False
+    timezone: str = ""
+    locale: str = ""
+    keyboard_layout: str = ""
+    player: str = "Chromium"
+    player_service: str = "xiboplayer-chromium.service"
+    cms_url: str = ""
+    cms_key: str = ""
+    display_name: str = ""
+    preseed_vars: dict[str, str] = field(default_factory=dict)
+    kiosk_dir: Path = Path("/usr/share/xiboplayer-kiosk")
+    config_dir: Path = Path.home() / ".config" / "xiboplayer"
+    data_dir: Path = Path.home() / ".local" / "share" / "xibo"
+
+    @classmethod
+    def load(cls) -> "KioskState":
+        s = cls()
+        s.preseed_vars = preseed.read_all()
+        s.refresh_all()
+        return s
+
+    def refresh_all(self) -> None:
+        self.refresh_wifi()
+        self.refresh_timezone()
+        self.refresh_locale()
+        self.refresh_keyboard()
+        self.refresh_player()
+        self.refresh_cms()
+
+    def refresh_wifi(self) -> None:
+        self.wifi_ssid = status.wifi_status()
+        self.wifi_hardware_present = not self.wifi_ssid.startswith("(no wifi hardware")
+        self.wired_connected = self.wifi_ssid == "(wired)"
+
+    def refresh_timezone(self) -> None:
+        self.timezone = status.timezone_status()
+
+    def refresh_locale(self) -> None:
+        self.locale = status.locale_status()
+
+    def refresh_keyboard(self) -> None:
+        self.keyboard_layout = status.keyboard_status()
+
+    def refresh_player(self) -> None:
+        self.player, self.player_service = status.player_status(self.config_dir)
+
+    def refresh_cms(self) -> None:
+        self.cms_url = status.cms_status(self.config_dir, self.data_dir, self.player)

--- a/kiosk/xiboplayer_kiosk/tests/test_branding.py
+++ b/kiosk/xiboplayer_kiosk/tests/test_branding.py
@@ -1,0 +1,24 @@
+from xiboplayer_kiosk import branding
+
+
+def test_brand_colors_unchanged():
+    assert branding.BRAND_XIBO_COLOR == "#0097D8"
+    assert branding.BRAND_PLAYER_COLOR == "#FFFFFF"
+
+
+def test_heading_contains_both_colors():
+    assert "#0097D8" in branding.BRAND_HEADING_MARKUP
+    assert "#FFFFFF" in branding.BRAND_HEADING_MARKUP
+    assert "xibo" in branding.BRAND_HEADING_MARKUP
+    assert "player" in branding.BRAND_HEADING_MARKUP
+
+
+def test_branded_heading_adds_subtitle():
+    out = branding.branded_heading("First boot setup")
+    assert "First boot setup" in out
+    assert "size=\"small\"" in out
+
+
+def test_branded_heading_no_subtitle():
+    out = branding.branded_heading("")
+    assert "size=\"small\"" not in out

--- a/kiosk/xiboplayer_kiosk/tests/test_cms.py
+++ b/kiosk/xiboplayer_kiosk/tests/test_cms.py
@@ -1,0 +1,85 @@
+"""Tests for services.cms — player config writers.
+
+These are the functions previously implemented as zlib_write_chromium_config,
+zlib_write_electron_config, zlib_write_arexibo_cms_json in xibo-zenity-lib.sh.
+Each writer produces a JSON file at a player-specific path; tests verify the
+file layout, URL normalisation (trailing slash), and merge-with-existing-json
+behaviour.
+"""
+
+import json
+
+from xiboplayer_kiosk.services import cms
+
+
+def test_chromium_writes_expected_keys(tmp_path):
+    cms.write_chromium(tmp_path, "https://cms.test", "KEY", "Kiosk-1")
+    data = json.loads((tmp_path / "chromium" / "config.json").read_text())
+    assert data["cmsUrl"] == "https://cms.test/"
+    assert data["cmsKey"] == "KEY"
+    assert data["displayName"] == "Kiosk-1"
+
+
+def test_chromium_adds_trailing_slash_if_missing(tmp_path):
+    cms.write_chromium(tmp_path, "https://cms.test", "K", "D")
+    data = json.loads((tmp_path / "chromium" / "config.json").read_text())
+    assert data["cmsUrl"].endswith("/")
+
+
+def test_chromium_preserves_trailing_slash(tmp_path):
+    cms.write_chromium(tmp_path, "https://cms.test/", "K", "D")
+    data = json.loads((tmp_path / "chromium" / "config.json").read_text())
+    assert data["cmsUrl"] == "https://cms.test/"
+
+
+def test_chromium_merges_with_existing_config(tmp_path):
+    (tmp_path / "chromium").mkdir()
+    (tmp_path / "chromium" / "config.json").write_text(
+        json.dumps({"customSetting": "preserved", "cmsUrl": "old"}),
+    )
+    cms.write_chromium(tmp_path, "https://new/", "K", "D")
+    data = json.loads((tmp_path / "chromium" / "config.json").read_text())
+    assert data["customSetting"] == "preserved"  # merge preserved non-CMS keys
+    assert data["cmsUrl"] == "https://new/"
+
+
+def test_electron_writes_expected_keys(tmp_path):
+    cms.write_electron(tmp_path, "https://cms.test/", "K", "D")
+    data = json.loads((tmp_path / "electron" / "config.json").read_text())
+    assert data["cmsUrl"] == "https://cms.test/"
+
+
+def test_arexibo_generates_hwkey(tmp_path):
+    cms.write_arexibo(tmp_path, "https://cms.test/", "K", "My-Kiosk")
+    data = json.loads((tmp_path / "cms.json").read_text())
+    assert data["address"] == "https://cms.test/"
+    assert data["displayId"].startswith("xibo-")
+    assert len(data["displayId"]) == len("xibo-") + 12  # 6 hex bytes = 12 chars
+    assert data["displayName"] == "My-Kiosk"
+
+
+def test_arexibo_uses_hwkey_as_displayname_when_empty(tmp_path):
+    cms.write_arexibo(tmp_path, "https://cms.test/", "K", "")
+    data = json.loads((tmp_path / "cms.json").read_text())
+    assert data["displayName"] == data["displayId"]
+
+
+def test_write_for_player_dispatches_chromium(tmp_path):
+    cms.write_for_player("Chromium", tmp_path, tmp_path, "https://cms/", "K", "D")
+    assert (tmp_path / "chromium" / "config.json").exists()
+    assert not (tmp_path / "electron" / "config.json").exists()
+
+
+def test_write_for_player_dispatches_electron(tmp_path):
+    cms.write_for_player("Electron", tmp_path, tmp_path, "https://cms/", "K", "D")
+    assert (tmp_path / "electron" / "config.json").exists()
+
+
+def test_write_for_player_dispatches_arexibo(tmp_path):
+    cms.write_for_player("Arexibo", tmp_path, tmp_path, "https://cms/", "K", "D")
+    assert (tmp_path / "cms.json").exists()
+
+
+def test_write_for_player_unknown_falls_back_to_chromium(tmp_path):
+    cms.write_for_player("Unknown", tmp_path, tmp_path, "https://cms/", "K", "D")
+    assert (tmp_path / "chromium" / "config.json").exists()

--- a/kiosk/xiboplayer_kiosk/tests/test_doas_runner.py
+++ b/kiosk/xiboplayer_kiosk/tests/test_doas_runner.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from xiboplayer_kiosk.doas_runner import DoasRunner
+
+
+def test_run_success(monkeypatch):
+    class FakeResult:
+        returncode = 0
+        stdout = "ok\n"
+        stderr = ""
+
+    with patch("subprocess.run", return_value=FakeResult()):
+        r = DoasRunner().run("xibo-set-timezone.sh", "Europe/Madrid")
+    assert r == (True, "ok\n")
+
+
+def test_run_failure_captures_stderr(monkeypatch):
+    class FakeResult:
+        returncode = 1
+        stdout = ""
+        stderr = "permission denied\n"
+
+    with patch("subprocess.run", return_value=FakeResult()):
+        ok, out = DoasRunner().run("xibo-set-wifi.sh", "MyWiFi", "secret")
+    assert ok is False
+    assert "permission denied" in out
+
+
+def test_run_timeout_returns_false(monkeypatch):
+    import subprocess as sp
+    with patch("subprocess.run", side_effect=sp.TimeoutExpired("doas", 30)):
+        ok, out = DoasRunner().run("xibo-set-wifi.sh", "SlowNet", timeout=30)
+    assert ok is False
+    assert "timed out" in out
+
+
+def test_run_missing_script_returns_false(monkeypatch):
+    with patch("subprocess.run", side_effect=FileNotFoundError()):
+        ok, out = DoasRunner().run("xibo-set-nonexistent.sh")
+    assert ok is False
+    assert "not found" in out

--- a/kiosk/xiboplayer_kiosk/tests/test_locale_list.py
+++ b/kiosk/xiboplayer_kiosk/tests/test_locale_list.py
@@ -1,0 +1,58 @@
+"""Tests for services.locale — list filtering.
+
+The filter strips @variants + non-UTF-8 encodings + C.*/POSIX — same
+rules as kiosk/xibo-first-boot.sh handle_language used to apply via
+`grep -Ev '@|\\.iso...' | grep -v '^C\\.' | grep -v '^POSIX$'`.
+"""
+
+from unittest.mock import patch
+
+from xiboplayer_kiosk.services import locale
+
+
+class FakeProc:
+    def __init__(self, stdout, returncode=0):
+        self.stdout = stdout
+        self.returncode = returncode
+
+
+def test_keeps_utf8_locales(monkeypatch):
+    stdout = "en_US.UTF-8\nes_ES.UTF-8\nca_ES.UTF-8\nfr_FR.UTF-8\n"
+    with patch("subprocess.run", return_value=FakeProc(stdout)):
+        got = locale.list_locales()
+    assert got == ["en_US.UTF-8", "es_ES.UTF-8", "ca_ES.UTF-8", "fr_FR.UTF-8"]
+
+
+def test_filters_variant_suffix(monkeypatch):
+    stdout = (
+        "es_ES.UTF-8\n"
+        "es_ES@euro\n"            # @variant — drop
+        "es_ES.UTF-8@euro\n"      # @variant — drop
+    )
+    with patch("subprocess.run", return_value=FakeProc(stdout)):
+        got = locale.list_locales()
+    assert got == ["es_ES.UTF-8"]
+
+
+def test_filters_legacy_encodings(monkeypatch):
+    stdout = (
+        "en_GB.UTF-8\n"
+        "en_GB.ISO-8859-1\n"      # iso-8859 — drop
+        "en_GB.iso88591\n"        # alt spelling — drop
+        "ru_RU.KOI8-R\n"          # koi — drop
+    )
+    with patch("subprocess.run", return_value=FakeProc(stdout)):
+        got = locale.list_locales()
+    assert got == ["en_GB.UTF-8"]
+
+
+def test_filters_c_and_posix(monkeypatch):
+    stdout = "C.UTF-8\nPOSIX\nen_US.UTF-8\n"
+    with patch("subprocess.run", return_value=FakeProc(stdout)):
+        got = locale.list_locales()
+    assert got == ["en_US.UTF-8"]
+
+
+def test_empty_on_failure(monkeypatch):
+    with patch("subprocess.run", return_value=FakeProc("", returncode=1)):
+        assert locale.list_locales() == []

--- a/kiosk/xiboplayer_kiosk/tests/test_preseed.py
+++ b/kiosk/xiboplayer_kiosk/tests/test_preseed.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from xiboplayer_kiosk import preseed
+
+
+def test_read_returns_empty_when_file_missing(tmp_path):
+    assert preseed.read("xibo.cms_url", tmp_path / "nope") == ""
+
+
+def test_read_extracts_value(tmp_path):
+    p = tmp_path / "preseed.env"
+    p.write_text(
+        "xibo.cms_url=https://cms.example.com/\n"
+        "xibo.cms_key=ABC123\n"
+        "xibo.display_name=kiosk-01\n",
+    )
+    assert preseed.read("xibo.cms_url", p) == "https://cms.example.com/"
+    assert preseed.read("xibo.cms_key", p) == "ABC123"
+
+
+def test_read_returns_empty_for_absent_key(tmp_path):
+    p = tmp_path / "preseed.env"
+    p.write_text("xibo.foo=bar\n")
+    assert preseed.read("xibo.missing", p) == ""
+
+
+def test_read_never_evaluates_shell_metachars(tmp_path):
+    # If we'd `source` the file, this would run `rm /tmp/bogus`. We don't.
+    p = tmp_path / "preseed.env"
+    p.write_text("xibo.evil=`rm /tmp/bogus`\n")
+    assert preseed.read("xibo.evil", p) == "`rm /tmp/bogus`"
+
+
+def test_read_all_skips_comments_and_blank(tmp_path):
+    p = tmp_path / "preseed.env"
+    p.write_text("# comment\n\nkey1=val1\nkey2=val2\n")
+    assert preseed.read_all(p) == {"key1": "val1", "key2": "val2"}

--- a/kiosk/xiboplayer_kiosk/tests/test_state.py
+++ b/kiosk/xiboplayer_kiosk/tests/test_state.py
@@ -1,0 +1,56 @@
+"""Tests for state.KioskState.
+
+We stub the subprocess-driven refreshes by patching the imported
+`status` module functions; state construction + refresh dispatch is
+what's tested here, not the underlying system probes.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from xiboplayer_kiosk.state import KioskState
+
+
+def test_load_populates_preseed(tmp_path, monkeypatch):
+    preseed_file = tmp_path / "preseed.env"
+    preseed_file.write_text("xibo.cms_url=https://cms/\nxibo.display_name=kiosk-7\n")
+    monkeypatch.setattr("xiboplayer_kiosk.preseed.PRESEED_PATH", preseed_file)
+    with patch("xiboplayer_kiosk.services.status.wifi_status", return_value="(wired)"), \
+         patch("xiboplayer_kiosk.services.status.timezone_status", return_value="UTC"), \
+         patch("xiboplayer_kiosk.services.status.locale_status", return_value="en_US.UTF-8"), \
+         patch("xiboplayer_kiosk.services.status.keyboard_status", return_value="us"), \
+         patch("xiboplayer_kiosk.services.status.player_status", return_value=("Chromium", "xiboplayer-chromium.service")), \
+         patch("xiboplayer_kiosk.services.status.cms_status", return_value="https://cms/"):
+        s = KioskState.load()
+    assert s.preseed_vars["xibo.cms_url"] == "https://cms/"
+    assert s.preseed_vars["xibo.display_name"] == "kiosk-7"
+    assert s.timezone == "UTC"
+    assert s.locale == "en_US.UTF-8"
+    assert s.player == "Chromium"
+    assert s.wifi_ssid == "(wired)"
+    assert s.wired_connected is True
+    assert s.wifi_hardware_present is True
+
+
+def test_refresh_wifi_no_hardware():
+    s = KioskState()
+    with patch("xiboplayer_kiosk.services.status.wifi_status", return_value="(no wifi hardware)"):
+        s.refresh_wifi()
+    assert s.wifi_hardware_present is False
+    assert s.wired_connected is False
+
+
+def test_refresh_player_sets_service():
+    s = KioskState()
+    with patch(
+        "xiboplayer_kiosk.services.status.player_status",
+        return_value=("Electron", "xiboplayer-electron.service"),
+    ):
+        s.refresh_player()
+    assert s.player == "Electron"
+    assert s.player_service == "xiboplayer-electron.service"
+
+
+def test_default_kiosk_dir():
+    s = KioskState()
+    assert s.kiosk_dir == Path("/usr/share/xiboplayer-kiosk")

--- a/kiosk/xiboplayer_kiosk/tests/test_status.py
+++ b/kiosk/xiboplayer_kiosk/tests/test_status.py
@@ -1,0 +1,89 @@
+"""Tests for services.status — system probes with subprocess mocked out."""
+
+import json
+from unittest.mock import patch
+
+from xiboplayer_kiosk.services import status
+
+
+class FakeProc:
+    def __init__(self, stdout="", returncode=0):
+        self.stdout = stdout
+        self.returncode = returncode
+
+
+def test_wifi_status_returns_active_ssid(monkeypatch):
+    # First call = dev status list; second = active conn list
+    def fake_run(cmd, **kw):
+        if "dev" in cmd and "status" in cmd:
+            return FakeProc("wlp3s0:wifi\n")
+        if "conn" in cmd:
+            return FakeProc("HomeWiFi:802-11-wireless:activated\n")
+        return FakeProc("")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        assert status.wifi_status() == "HomeWiFi"
+
+
+def test_wifi_status_reports_wired(monkeypatch):
+    def fake_run(cmd, **kw):
+        if "dev" in cmd and "status" in cmd:
+            return FakeProc("wlp3s0:wifi\nenp0s31f6:ethernet\n")
+        if "conn" in cmd:
+            return FakeProc("EthernetA:802-3-ethernet:activated\n")
+        return FakeProc("")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        assert status.wifi_status() == "(wired)"
+
+
+def test_wifi_status_no_hardware(monkeypatch):
+    with patch("subprocess.run", return_value=FakeProc("enp0s31f6:ethernet\n")):
+        assert status.wifi_status().startswith("(no wifi hardware")
+
+
+def test_player_status_default_on_missing_file(tmp_path):
+    player, service = status.player_status(tmp_path)
+    assert player == "Chromium"
+    assert service == "xiboplayer-chromium.service"
+
+
+def test_player_status_reads_json(tmp_path):
+    (tmp_path / "setup-result.json").write_text(
+        json.dumps({"player": "Electron", "service": "xiboplayer-electron.service"}),
+    )
+    player, service = status.player_status(tmp_path)
+    assert player == "Electron"
+    assert service == "xiboplayer-electron.service"
+
+
+def test_player_status_default_on_bad_json(tmp_path):
+    (tmp_path / "setup-result.json").write_text("{not json")
+    player, _ = status.player_status(tmp_path)
+    assert player == "Chromium"
+
+
+def test_cms_status_chromium_config(tmp_path):
+    d = tmp_path / "chromium"
+    d.mkdir()
+    (d / "config.json").write_text(json.dumps({"cmsUrl": "https://c/", "cmsKey": "K"}))
+    assert status.cms_status(tmp_path, tmp_path, "Chromium") == "https://c/"
+
+
+def test_cms_status_arexibo_uses_address(tmp_path):
+    (tmp_path / "cms.json").write_text(json.dumps({"address": "https://arx/", "key": "K"}))
+    assert status.cms_status(tmp_path, tmp_path, "Arexibo") == "https://arx/"
+
+
+def test_cms_status_unconfigured(tmp_path):
+    assert status.cms_status(tmp_path, tmp_path, "Chromium") == "(not configured)"
+
+
+def test_timezone_status(monkeypatch):
+    with patch("subprocess.run", return_value=FakeProc("Europe/Madrid\n")):
+        assert status.timezone_status() == "Europe/Madrid"
+
+
+def test_timezone_status_fallback_on_empty(monkeypatch):
+    with patch("subprocess.run", return_value=FakeProc("", returncode=1)):
+        assert status.timezone_status() == "(unknown)"

--- a/kiosk/xiboplayer_kiosk/tests/test_wifi.py
+++ b/kiosk/xiboplayer_kiosk/tests/test_wifi.py
@@ -1,0 +1,90 @@
+"""Tests for services.wifi — nmcli output parsing.
+
+The tricky part is the colon-separated, backslash-escaped nmcli -t format;
+we test the split helper + the list_networks() post-processing without
+actually shelling out.
+"""
+
+from unittest.mock import patch
+
+from xiboplayer_kiosk.services import wifi
+
+
+def test_split_nmcli_line_plain():
+    assert wifi._split_nmcli_line("*:MyWiFi:85:WPA2") == ["*", "MyWiFi", "85", "WPA2"]
+
+
+def test_split_nmcli_line_handles_escaped_colon():
+    # SSID containing a literal ":" — nmcli escapes as \:
+    assert wifi._split_nmcli_line(r":net\:work:70:open") == ["", "net:work", "70", "open"]
+
+
+def test_split_nmcli_line_empty_fields():
+    assert wifi._split_nmcli_line(":::" ) == ["", "", "", ""]
+
+
+class FakeProc:
+    def __init__(self, stdout="", returncode=0):
+        self.stdout = stdout
+        self.returncode = returncode
+
+
+def test_list_networks_dedupes_by_ssid(monkeypatch):
+    stdout = (
+        " :NetA:80:WPA2\n"
+        " :NetA:70:WPA2\n"  # duplicate, should be dropped
+        " :NetB:60:open\n"
+    )
+    with patch("subprocess.run", return_value=FakeProc(stdout)):
+        nets = wifi.list_networks()
+    ssids = [n.ssid for n in nets]
+    assert ssids == ["NetA", "NetB"]  # sorted by signal desc, deduped
+
+
+def test_list_networks_maps_empty_security_to_open(monkeypatch):
+    stdout = " :NetOpen:65:--\n"
+    with patch("subprocess.run", return_value=FakeProc(stdout)):
+        nets = wifi.list_networks()
+    assert len(nets) == 1
+    assert nets[0].security == "open"
+
+
+def test_list_networks_sorted_by_signal_desc(monkeypatch):
+    stdout = (
+        " :NetLow:20:open\n"
+        " :NetHigh:90:open\n"
+        " :NetMid:50:open\n"
+    )
+    with patch("subprocess.run", return_value=FakeProc(stdout)):
+        nets = wifi.list_networks()
+    assert [n.ssid for n in nets] == ["NetHigh", "NetMid", "NetLow"]
+
+
+def test_list_networks_marks_in_use(monkeypatch):
+    stdout = (
+        "*:HomeWiFi:95:WPA2\n"
+        " :Other:50:WPA2\n"
+    )
+    with patch("subprocess.run", return_value=FakeProc(stdout)):
+        nets = wifi.list_networks()
+    home = next(n for n in nets if n.ssid == "HomeWiFi")
+    assert home.in_use is True
+    other = next(n for n in nets if n.ssid == "Other")
+    assert other.in_use is False
+
+
+def test_list_networks_empty_on_nmcli_failure(monkeypatch):
+    with patch("subprocess.run", return_value=FakeProc("", returncode=1)):
+        assert wifi.list_networks() == []
+
+
+def test_has_wifi_hardware_true(monkeypatch):
+    stdout = "wlp3s0:wifi:connected\nenp0s31f6:ethernet:unavailable\n"
+    with patch("subprocess.run", return_value=FakeProc(stdout)):
+        assert wifi.has_wifi_hardware() is True
+
+
+def test_has_wifi_hardware_false_wired_only(monkeypatch):
+    stdout = "enp0s31f6:ethernet:connected\n"
+    with patch("subprocess.run", return_value=FakeProc(stdout)):
+        assert wifi.has_wifi_hardware() is False

--- a/rpm/xiboplayer-kiosk.spec
+++ b/rpm/xiboplayer-kiosk.spec
@@ -1,5 +1,5 @@
 Name:           xiboplayer-kiosk
-Version:        0.4.36
+Version:        0.5.0
 Release:        1%{?dist}
 Summary:        Kiosk session scripts for Xibo digital signage players
 
@@ -197,6 +197,9 @@ install -m755 kiosk/gnome-kiosk-script.sh %{buildroot}%{_sysconfdir}/skel/.local
 /usr/bin/dconf update &>/dev/null || :
 
 %changelog
+* Mon Apr 13 2026 Pau Aliagas <linuxnow@gmail.com> - 0.5.0-1
+- Python + GTK4 + libadwaita first-boot wizard (sidebar + content panels).
+
 * Sun Apr 12 2026 Pau Aliagas <linuxnow@gmail.com> - 0.4.36-1
 - First-boot Language/Timezone/Keyboard/Wi-Fi rows use xibo-picker.py live-filter GTK4+libadwaita dialog (#119).
 

--- a/rpm/xiboplayer-kiosk.spec
+++ b/rpm/xiboplayer-kiosk.spec
@@ -87,6 +87,28 @@ install -Dm755 kiosk/xibo-set-keyboard.sh %{buildroot}%{_datadir}/xiboplayer-kio
 # Called by xibo-first-boot.sh for the Language / Timezone / Keyboard /
 # Wi-Fi rows, replacing the prior two-stage zenity entry+list flow.
 install -Dm755 kiosk/xibo-picker.py %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-picker.py
+
+# PR1+PR2 (Python rewrite) — install the xiboplayer_kiosk package tree
+# and the two entry-point wrappers. Replaces xibo-first-boot.sh,
+# xibo-show-cms.sh, xibo-zenity-lib.sh, and xibo-picker.py (those remain
+# installed but are no longer invoked — removed in a follow-up PR).
+install -d %{buildroot}%{_datadir}/xiboplayer-kiosk/xiboplayer_kiosk
+install -d %{buildroot}%{_datadir}/xiboplayer-kiosk/xiboplayer_kiosk/services
+install -d %{buildroot}%{_datadir}/xiboplayer-kiosk/xiboplayer_kiosk/dialogs
+for f in kiosk/xiboplayer_kiosk/*.py; do
+    install -Dm644 "$f" %{buildroot}%{_datadir}/xiboplayer-kiosk/xiboplayer_kiosk/$(basename "$f")
+done
+for f in kiosk/xiboplayer_kiosk/services/*.py; do
+    install -Dm644 "$f" %{buildroot}%{_datadir}/xiboplayer-kiosk/xiboplayer_kiosk/services/$(basename "$f")
+done
+for f in kiosk/xiboplayer_kiosk/dialogs/*.py; do
+    install -Dm644 "$f" %{buildroot}%{_datadir}/xiboplayer-kiosk/xiboplayer_kiosk/dialogs/$(basename "$f")
+done
+# Entry-point wrappers — invoked by gnome-kiosk-script.xibo.sh +
+# keyd-xibo.conf. No `.sh` extension so they stay invocable after PR3
+# drops the old shell scripts.
+install -Dm755 kiosk/xibo-first-boot  %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-first-boot
+install -Dm755 kiosk/xibo-reconfigure %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-reconfigure
 install -Dm755 kiosk/xibo-keyd-open-terminal.sh %{buildroot}%{_datadir}/xiboplayer-kiosk/xibo-keyd-open-terminal.sh
 # Issue #102 branding — xiboplayer logo (used as zenity dialog window
 # icon in the first-boot menu splash, among other places).
@@ -141,6 +163,14 @@ install -m755 kiosk/gnome-kiosk-script.sh %{buildroot}%{_sysconfdir}/skel/.local
 %{_datadir}/xiboplayer-kiosk/xibo-set-player.sh
 %{_datadir}/xiboplayer-kiosk/xibo-set-keyboard.sh
 %{_datadir}/xiboplayer-kiosk/xibo-picker.py
+%dir %{_datadir}/xiboplayer-kiosk/xiboplayer_kiosk
+%dir %{_datadir}/xiboplayer-kiosk/xiboplayer_kiosk/services
+%dir %{_datadir}/xiboplayer-kiosk/xiboplayer_kiosk/dialogs
+%{_datadir}/xiboplayer-kiosk/xiboplayer_kiosk/*.py
+%{_datadir}/xiboplayer-kiosk/xiboplayer_kiosk/services/*.py
+%{_datadir}/xiboplayer-kiosk/xiboplayer_kiosk/dialogs/*.py
+%{_datadir}/xiboplayer-kiosk/xibo-first-boot
+%{_datadir}/xiboplayer-kiosk/xibo-reconfigure
 %{_datadir}/xiboplayer-kiosk/xibo-keyd-open-terminal.sh
 %{_datadir}/xiboplayer-kiosk/xibo-usb-preseed.sh
 %{_datadir}/xiboplayer-kiosk/xiboplayer-kiosk-logo.png


### PR DESCRIPTION
Complete UX rewrite of first-boot + reconfigure wizards. Closes the zenity/shell/xibo-picker.py fragmentation that caused visual inconsistency, silent failures, and the dep-tree cascade class of bugs we debugged all day yesterday.

## What's new

- **Single window**, GNOME Settings-style sidebar + content (`Adw.NavigationSplitView`)
- 7 persistent sidebar categories (Language / Keyboard / Wi-Fi / Timezone / Player / CMS / Settings) with live status subtitles
- Click a row → its panel fills the right pane (no new windows)
- Picker input fields match CMS form via `Adw.EntryRow` in `Adw.PreferencesGroup`
- Filter-as-you-type via `Gtk.FilterListModel`
- xiboplayer logo on the welcome page, compact layout (no big middle gap)
- Esc closes pickers (capture-phase key controller beats EntryRow's default handler)

## Package layout

\`\`\`
kiosk/xiboplayer_kiosk/
  app.py, __main__.py, __init__.py, branding.py, state.py,
  preseed.py, doas_runner.py
  dialogs/ — window, panels, info, wifi_password, base
  services/ — status, locale, timezone, keyboard, wifi, cms, notify
  tests/   — 54 unit tests passing
kiosk/xibo-first-boot   — entry-point wrapper
kiosk/xibo-reconfigure  — entry-point wrapper (Ctrl+R)
\`\`\`

Old shell scripts (xibo-first-boot.sh, xibo-show-cms.sh, xibo-zenity-lib.sh, xibo-picker.py) still installed but no longer invoked; cleanup in 0.5.1.

## Packaging + wiring

- RPM spec + deb builder install the package tree + entry-points
- \`gnome-kiosk-script.xibo.sh\` prefers the new \`xibo-first-boot\` wrapper, falls back to the shell one
- \`keyd-xibo.conf\` Ctrl+R maps to \`xibo-reconfigure\`
- Fix: dropped \`intel-media-driver\` and \`keyd\` from \`%packages\` — RPM Fusion non-free / COPR packages aren't available at anaconda stage-1; installed in %post after xiboplayer-release enables those repos
- Fix: kickstart uses \`@^custom-environment\` (the only environment ID present on F43; \`@^minimal-environment\` doesn't exist as an installable environment there)

## Testing

- Test ISO verified: zero-touch text install, kiosk session boots, all 7 sidebar categories render, pickers filter live, CMS form writes config.json, Start player closes wizard.
- 54 unit tests cover branding / preseed / doas_runner / state / cms writers / wifi parser / locale filter / status probes.

## Next

- 0.5.1: delete the old shell scripts (PR3 from blueprint)
- 0.6.0: Plymouth theme + branded anaconda sidebar (PR4 blueprint ready)
- Horizon: headless captive-portal flow for screenless kiosks (DNSMASQ + Apache wallgarden)