### PR TITLE
fix(ci): atomic.yml waits for RPM in repo before installing it

### DIFF
--- a/.github/workflows/atomic.yml
+++ b/.github/workflows/atomic.yml
@@ -24,10 +24,47 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # ── Pre-flight: wait for current xiboplayer-kiosk RPM to appear ──
+  # On tag-triggered runs, this workflow fires concurrently with
+  # rpm.yml. The atomic Containerfile then runs `dnf install
+  # xiboplayer-kiosk` which races against rpm.yml publishing the new
+  # version to dl.xiboplayer.org and intermittently fails with "No
+  # match for argument: xiboplayer-kiosk-X.Y.Z". Polling for the
+  # version-stamped RPM to land in the repo before we proceed makes
+  # the tag-push release flow reliable. Skipped on non-tag runs (the
+  # nightly cron + manual dispatch don't bump the version).
+  preflight-rpm:
+    name: Wait for xiboplayer-kiosk RPM in repo
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Poll dl.xiboplayer.org for the tag's RPM
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          set -eu
+          # Strip leading 'v' to get the bare version string
+          VER="${VERSION#v}"
+          URL="https://dl.xiboplayer.org/rpm/fedora/43/noarch/xiboplayer-kiosk-${VER}-1.fc43.noarch.rpm"
+          echo "Waiting for $URL"
+          for i in $(seq 1 60); do
+            if curl -sfI -o /dev/null "$URL"; then
+              echo "RPM published — proceeding."
+              exit 0
+            fi
+            echo "Not yet (attempt $i/60), sleeping 15s..."
+            sleep 15
+          done
+          echo "Timed out waiting for $URL after 15 minutes."
+          exit 1
+
   build-oci-x86_64:
     name: Build OCI Image (x86_64)
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: [preflight-rpm]
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') || needs.preflight-rpm.result == 'success' }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -60,6 +97,8 @@ jobs:
     name: Build OCI Image (aarch64)
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
+    needs: [preflight-rpm]
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') || needs.preflight-rpm.result == 'success' }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
Race-condition fix from v0.5.0 tag push: atomic.yml installed xiboplayer-kiosk-0.5.0 before rpm.yml had published it. Mirrors the existing preflight pattern in build-iso.yml.