### PR TITLE
ci(image): bump build-iso SHA pin to .github#33 (xorriso-replay grub fix)

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-iso.yml@a4fc03795a8235d87022e5e8330004b4a74f65a4  # main @ 2026-04-14 (drop xorriso post-patch — .github#32, closes #146)
+    uses: xibo-players/.github/.github/workflows/build-iso.yml@96da5ad926a365cb7d2fbde1d1d207253dd1c861  # main @ 2026-04-14 (xorriso post-patch with -boot_image any replay — .github#33, re-brands grub menu while preserving #146 fix)
     with:
       package-name: xiboplayer-kiosk
       kickstart-file: 'kickstart/xiboplayer-kiosk.ks'

--- a/.github/workflows/test-image.yml
+++ b/.github/workflows/test-image.yml
@@ -52,7 +52,7 @@ concurrency:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-iso.yml@a4fc03795a8235d87022e5e8330004b4a74f65a4  # main @ 2026-04-14 (drop xorriso post-patch — .github#32, closes #146)
+    uses: xibo-players/.github/.github/workflows/build-iso.yml@96da5ad926a365cb7d2fbde1d1d207253dd1c861  # main @ 2026-04-14 (xorriso post-patch with -boot_image any replay — .github#33, re-brands grub menu while preserving #146 fix)
     with:
       package-name: xiboplayer-kiosk
       kickstart-file: 'kickstart/xiboplayer-kiosk.ks'


### PR DESCRIPTION
## Summary

- Bumps SHA pin in `image.yml` and `test-image.yml` from `a4fc0379` (.github#32) to `96da5ad9` (.github#33)
- .github#33 restores the xorriso post-patch using \`-boot_image any replay\` to preserve boot metadata while substituting the two grub.cfg files

## Context

Issue #146 was declared fixed when .github#32 dropped the xorriso post-patch in favour of mkksiso \`--add\` overlay. Verification against build bc8f60b458ac showed the ISO boots (kernel-detection is genuinely fixed) but ships Fedora's stock menuentries — because mkksiso's internal EditGrub2 runs after \`--add\` and reverts the grub.cfg.

.github#33 fixes the overlay precedence without breaking the #146 boot metadata preservation. See xibo-players/.github#33 for the xorriso flag rationale.

## Test plan

- [ ] Kick off test-image.yml on this PR branch (or on main after merge)
- [ ] QEMU UEFI boot shows "Install xiboplayer-kiosk" branded menuentries
- [ ] QEMU UEFI install proceeds through anaconda → kiosk session (Stages A–E of TEST_PLAN_0.5.x.md)
- [ ] QEMU SeaBIOS (Stage H) still boots
- [ ] docs/TEST_PLAN_0.5.x.md bug #2 row flipped to ✅ verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)