### PR TITLE
ci: bump build-rpm/deb SHA pin to .github#35 (raw-armor GPG)

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   deb:
-    uses: xibo-players/.github/.github/workflows/build-deb.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
+    uses: xibo-players/.github/.github/workflows/build-deb.yml@99b65f33c5227c49a8f093cb776894ef82e4d77e  # main
     with:
       package-name: xiboplayer-kiosk
       deb-script: 'deb/build-deb.sh'

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   rpm:
-    uses: xibo-players/.github/.github/workflows/build-rpm.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
+    uses: xibo-players/.github/.github/workflows/build-rpm.yml@99b65f33c5227c49a8f093cb776894ef82e4d77e  # main
     with:
       package-name: xiboplayer-kiosk
       rpm-spec: 'rpm/xiboplayer-kiosk.spec'


### PR DESCRIPTION
Pins build-rpm.yml + build-deb.yml to the merge commit of xibo-players/.github#35, which drops the base64 decode step. Secrets now hold raw ASCII armor (verified by run 24441212661). Closes the loop on the signing-key misconfiguration that started with the 2026-04-14 org-secrets cleanup.