### PR TITLE
feat(wizard): regroup sidebar into Locality / CMS / Settings (0.5.2)

### DIFF
--- a/kiosk/xiboplayer_kiosk/app.py
+++ b/kiosk/xiboplayer_kiosk/app.py
@@ -34,7 +34,7 @@ from .services import timezone as tz_svc
 from .services import wifi as wifi_svc
 from .state import KioskState
 from .dialogs.info import ErrorDialog, InfoDialog
-from .dialogs.panels import CmsFormPanel, PickerPanel, PlayerPanel, SettingsPanel
+from .dialogs.panels import CmsFormPanel, LocalityPanel, PickerPanel, PlayerPanel, SettingsPanel
 from .dialogs.window import KioskWindow
 from .dialogs.wifi_password import WifiPasswordDialog
 
@@ -84,19 +84,46 @@ class KioskApp(Adw.Application):
     # ── category dispatch ───────────────────────────────────────────────
 
     def _on_category(self, category: str) -> None:
-        """User clicked a sidebar row — swap the content panel."""
+        """User clicked a sidebar row — swap the content panel.
+
+        Top-level sidebar has only three rows: Locality, CMS, Settings.
+        Locality contains Language/Keyboard/Timezone sub-rows; Settings
+        contains Wi-Fi/Player plus the ops actions.
+        """
         dispatch = {
-            "language": self._show_language,
-            "keyboard": self._show_keyboard,
-            "wifi":     self._show_wifi,
-            "timezone": self._show_timezone,
-            "player":   self._show_player,
+            "locality": self._show_locality,
             "cms":      self._show_cms,
             "settings": self._show_settings,
         }
         fn = dispatch.get(category)
         if fn:
             fn()
+
+    # ── Locality overview + sub-picker dispatch ─────────────────────────
+
+    def _show_locality(self) -> None:
+        """Locality overview — shows current Language/Keyboard/Timezone.
+
+        Clicking a row opens the corresponding picker; after a successful
+        apply, the picker's apply callback navigates back here so the
+        operator sees the new value in the row subtitle.
+        """
+        s = self.state
+        panel = LocalityPanel(
+            locale=s.locale,
+            keyboard=s.keyboard_layout,
+            timezone=s.timezone,
+            on_pick=self._locality_pick,
+        )
+        self._window.set_content_panel("Locality", panel)
+
+    def _locality_pick(self, action: str) -> None:
+        if action == "language":
+            self._show_language()
+        elif action == "keyboard":
+            self._show_keyboard()
+        elif action == "timezone":
+            self._show_timezone()
 
     # ── content panels ──────────────────────────────────────────────────
 
@@ -108,7 +135,9 @@ class KioskApp(Adw.Application):
             min_chars=2,
             placeholder="Type a locale code (e.g. en, en_GB, ca, es, fr, de)",
             apply_label="Set language",
-            on_apply=lambda v: self._apply_via_doas("xibo-set-locale.sh", v, "Language"),
+            on_apply=lambda v: self._apply_via_doas(
+                "xibo-set-locale.sh", v, "Language", back_to=self._show_locality,
+            ),
         )
         self._window.set_content_panel("Language", panel)
 
@@ -120,7 +149,9 @@ class KioskApp(Adw.Application):
             min_chars=2,
             placeholder="Type a layout code or country (e.g. us, es, fr, gb)",
             apply_label="Set keyboard",
-            on_apply=lambda v: self._apply_via_doas("xibo-set-keyboard.sh", v, "Keyboard"),
+            on_apply=lambda v: self._apply_via_doas(
+                "xibo-set-keyboard.sh", v, "Keyboard", back_to=self._show_locality,
+            ),
         )
         self._window.set_content_panel("Keyboard", panel)
 
@@ -132,7 +163,9 @@ class KioskApp(Adw.Application):
             min_chars=2,
             placeholder="Type UTC or a city (e.g. UTC, New_York, London, Tokyo)",
             apply_label="Set timezone",
-            on_apply=lambda v: self._apply_via_doas("xibo-set-timezone.sh", v, "Timezone"),
+            on_apply=lambda v: self._apply_via_doas(
+                "xibo-set-timezone.sh", v, "Timezone", back_to=self._show_locality,
+            ),
         )
         self._window.set_content_panel("Timezone", panel)
 
@@ -197,6 +230,8 @@ class KioskApp(Adw.Application):
         else:
             ErrorDialog(subtitle="Wi-Fi", body=f"Failed to connect to {ssid}.\n\n{err}").present(self._window)
         self._window.refresh_sidebar()
+        # Back to the Settings overview (same parent as Wi-Fi sub-picker).
+        self._show_settings()
 
     def _show_player(self) -> None:
         panel = PlayerPanel(
@@ -216,6 +251,8 @@ class KioskApp(Adw.Application):
         else:
             ErrorDialog(subtitle="Player", body=f"Failed to switch player.\n\n{err}").present(self._window)
         self._window.refresh_sidebar()
+        # Back to Settings overview (Player sub-picker's parent).
+        self._show_settings()
 
     def _show_cms(self) -> None:
         s = self.state
@@ -236,10 +273,28 @@ class KioskApp(Adw.Application):
         self._window.refresh_sidebar()
 
     def _show_settings(self) -> None:
-        panel = SettingsPanel(on_pick=self._settings_pick)
+        s = self.state
+        wifi_sub = s.wifi_ssid if s.wifi_ssid else (
+            "(not connected)" if s.wifi_hardware_present else "(no wireless hardware)"
+        )
+        panel = SettingsPanel(
+            wifi_subtitle=wifi_sub,
+            player_subtitle=s.player or "(unknown)",
+            on_pick=self._settings_pick,
+        )
         self._window.set_content_panel("Settings", panel)
 
     def _settings_pick(self, action: str) -> None:
+        # Wi-Fi + Player are "sub-pickers": clicking them opens a picker
+        # panel in the content pane (not a modal), same pattern as
+        # Locality sub-rows. After apply the callback navigates back to
+        # the Settings overview so the new value is visible.
+        if action == "wifi":
+            self._show_wifi()
+            return
+        if action == "player":
+            self._show_player()
+            return
         if action == "terminal":
             for cand in ("ptyxis", "kgx", "gnome-terminal", "xterm"):
                 try:
@@ -265,7 +320,7 @@ class KioskApp(Adw.Application):
 
     # ── helpers ─────────────────────────────────────────────────────────
 
-    def _apply_via_doas(self, helper: str, value: str, label: str) -> None:
+    def _apply_via_doas(self, helper: str, value: str, label: str, *, back_to=None) -> None:
         notify.send(f"Setting {label.lower()} to {value}...")
         ok, err = self.doas.run(helper, value)
         if ok:
@@ -273,6 +328,11 @@ class KioskApp(Adw.Application):
         else:
             ErrorDialog(subtitle=label, body=f"Failed to set {label} to {value}.\n\n{err}").present(self._window)
         self._window.refresh_sidebar()
+        # After apply, navigate back to the parent overview panel so the
+        # operator sees the new value in the row subtitle and doesn't
+        # stare at a stale picker wondering if anything happened.
+        if callable(back_to):
+            back_to()
 
     def _info_status_widget(self, *, icon: str, title: str, body: str) -> Adw.StatusPage:
         sp = Adw.StatusPage()

--- a/kiosk/xiboplayer_kiosk/dialogs/panels.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/panels.py
@@ -285,14 +285,20 @@ class PlayerPanel(Gtk.Box):
 # ───────────────────────────────────────────────────────────────────────
 
 
-class SettingsPanel(Gtk.Box):
-    """Sub-actions list: terminal / GNOME settings / debug bundle."""
+class _OverviewPanel(Gtk.Box):
+    """Reusable overview panel: a labelled PreferencesGroup of ActionRows.
+
+    Each row has a ``title``, a live ``subtitle`` showing the current
+    value, and activates an ``action_id`` on click. Used for both the
+    Locality overview (Language / Keyboard / Timezone) and the Settings
+    overview (Wi-Fi / Player / GNOME Settings / Open terminal / Debug).
+    """
 
     __gsignals__ = {
         "picked": (GObject.SignalFlags.RUN_FIRST, None, (str,)),
     }
 
-    def __init__(self, *, on_pick=None):
+    def __init__(self, *, rows, on_pick=None, group_description=None):
         super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=12)
         self.set_margin_top(12)
         self.set_margin_bottom(12)
@@ -301,11 +307,9 @@ class SettingsPanel(Gtk.Box):
         self._on_pick = on_pick
 
         group = Adw.PreferencesGroup()
-        for action_id, title, subtitle in (
-            ("gnome",    "GNOME Settings", "Advanced system tweaks"),
-            ("terminal", "Open terminal", "ptyxis (Ctrl+S also works)"),
-            ("debug",    "Collect debug bundle", "~/Downloads/xibo-debug-*.tar.zst"),
-        ):
+        if group_description:
+            group.set_description(group_description)
+        for action_id, title, subtitle in rows:
             row = Adw.ActionRow(title=title, subtitle=subtitle)
             row.set_activatable(True)
             row._action_id = action_id  # type: ignore[attr-defined]
@@ -319,3 +323,49 @@ class SettingsPanel(Gtk.Box):
         self.emit("picked", action)
         if callable(self._on_pick):
             self._on_pick(action)
+
+
+class LocalityPanel(_OverviewPanel):
+    """Locality overview — Language / Keyboard / Timezone with current values.
+
+    Clicking a row opens the corresponding picker; the controller
+    (``KioskApp``) navigates back to this overview after a successful
+    apply so the operator sees the new value in the subtitle.
+    """
+
+    def __init__(self, *, locale: str, keyboard: str, timezone: str, on_pick=None):
+        super().__init__(
+            group_description="Region and input settings",
+            rows=(
+                ("language", "Language", locale or "(not set)"),
+                ("keyboard", "Keyboard", keyboard or "(not set)"),
+                ("timezone", "Timezone", timezone or "(not set)"),
+            ),
+            on_pick=on_pick,
+        )
+
+
+class SettingsPanel(_OverviewPanel):
+    """Settings overview — Wi-Fi / Player / GNOME / terminal / debug.
+
+    Wi-Fi and Player live here (not at sidebar top-level) so the main
+    sidebar has only three category rows: Locality / CMS / Settings.
+    """
+
+    def __init__(
+        self,
+        *,
+        wifi_subtitle: str,
+        player_subtitle: str,
+        on_pick=None,
+    ):
+        super().__init__(
+            rows=(
+                ("wifi",     "Wi-Fi",               wifi_subtitle),
+                ("player",   "Player",              player_subtitle),
+                ("gnome",    "GNOME Settings",      "Advanced system tweaks"),
+                ("terminal", "Open terminal",       "ptyxis (Ctrl+S also works)"),
+                ("debug",    "Collect debug bundle", "~/Downloads/xibo-debug-*.tar.zst"),
+            ),
+            on_pick=on_pick,
+        )

--- a/kiosk/xiboplayer_kiosk/dialogs/window.py
+++ b/kiosk/xiboplayer_kiosk/dialogs/window.py
@@ -26,12 +26,13 @@ from gi.repository import Adw, Gdk, Gtk  # noqa: E402
 from .. import branding
 
 
+# Sidebar top-level categories. Grouped per user feedback to reduce
+# cognitive load — Locality bundles Language/Keyboard/Timezone,
+# Settings bundles Wi-Fi/Player and the ops actions (GNOME Settings,
+# terminal, debug bundle). Each group's overview panel lists sub-
+# actions with live subtitles showing the current value.
 _CATEGORIES = [
-    ("language", "Language"),
-    ("keyboard", "Keyboard"),
-    ("wifi",     "Wi-Fi"),
-    ("timezone", "Timezone"),
-    ("player",   "Player"),
+    ("locality", "Locality"),
     ("cms",      "CMS"),
     ("settings", "Settings"),
 ]
@@ -207,14 +208,14 @@ class KioskWindow(Adw.ApplicationWindow):
 
     def _sidebar_subtitle(self, category_id: str) -> str:
         s = self.state
+        # Locality + Settings show a condensed summary — the expanded
+        # per-row values live inside the category's overview panel.
+        locality_parts = [p for p in (s.locale, s.keyboard_layout, s.timezone) if p]
+        settings_parts = [s.wifi_ssid, s.player] if s.wifi_ssid else [s.player]
         return {
-            "language": s.locale or "(unknown)",
-            "keyboard": s.keyboard_layout,
-            "wifi":     s.wifi_ssid,
-            "timezone": s.timezone,
-            "player":   s.player,
+            "locality": " · ".join(locality_parts) or "(not set)",
             "cms":      s.cms_url,
-            "settings": "Terminal · GNOME Settings · Debug",
+            "settings": " · ".join(settings_parts),
         }.get(category_id, "")
 
     def _on_sidebar_row_activated(self, _box, row) -> None:

--- a/rpm/xiboplayer-kiosk.spec
+++ b/rpm/xiboplayer-kiosk.spec
@@ -1,5 +1,5 @@
 Name:           xiboplayer-kiosk
-Version:        0.5.1
+Version:        0.5.2
 Release:        1%{?dist}
 Summary:        Kiosk session scripts for Xibo digital signage players
 
@@ -201,6 +201,10 @@ install -Dm644 mkosi-extra/etc/chromium/policies/managed/xiboplayer-kiosk.json %
 /usr/bin/dconf update &>/dev/null || :
 
 %changelog
+* Wed Apr 15 2026 Pau Aliagas <linuxnow@gmail.com> - 0.5.2-1
+- Sidebar regrouped to 3 top-level rows: Locality / CMS / Settings.
+- Picker panels return to parent overview after apply (visible feedback).
+
 * Tue Apr 14 2026 Pau Aliagas <linuxnow@gmail.com> - 0.5.1-1
 - Rename dispatcher to xiboplayer-kiosk-session; drop /etc/skel install to avoid
   file conflict with gnome-kiosk-script-session default demo (#153).


### PR DESCRIPTION
Condenses 7 flat sidebar rows into 3 top-level groups per user UX feedback:

- **Locality** — Language + Keyboard + Timezone
- **CMS** — unchanged
- **Settings** — adds Wi-Fi + Player, keeps GNOME Settings / terminal / debug

New `_OverviewPanel` base class shared by Locality and Settings. After a picker's Apply button fires, the controller navigates back to the parent overview so the operator sees the updated subtitle value — fixes the 'did it work?' confusion of staying on the picker.

Bumps kiosk RPM 0.5.1 → 0.5.2.