### PR TITLE
ci: bump SHA pins to .github#36 (derive GPG key ID)

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   deb:
-    uses: xibo-players/.github/.github/workflows/build-deb.yml@99b65f33c5227c49a8f093cb776894ef82e4d77e  # main
+    uses: xibo-players/.github/.github/workflows/build-deb.yml@66aa291944bb2773302afcf6e13c1cec25ad5cbc  # main
     with:
       package-name: xiboplayer-kiosk
       deb-script: 'deb/build-deb.sh'

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-iso.yml@96da5ad926a365cb7d2fbde1d1d207253dd1c861  # main @ 2026-04-14 (xorriso post-patch with -boot_image any replay — .github#33, re-brands grub menu while preserving #146 fix)
+    uses: xibo-players/.github/.github/workflows/build-iso.yml@66aa291944bb2773302afcf6e13c1cec25ad5cbc  # main @ 2026-04-14 (xorriso post-patch with -boot_image any replay — .github#33, re-brands grub menu while preserving #146 fix)
     with:
       package-name: xiboplayer-kiosk
       kickstart-file: 'kickstart/xiboplayer-kiosk.ks'

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   rpm:
-    uses: xibo-players/.github/.github/workflows/build-rpm.yml@99b65f33c5227c49a8f093cb776894ef82e4d77e  # main
+    uses: xibo-players/.github/.github/workflows/build-rpm.yml@66aa291944bb2773302afcf6e13c1cec25ad5cbc  # main
     with:
       package-name: xiboplayer-kiosk
       rpm-spec: 'rpm/xiboplayer-kiosk.spec'

--- a/.github/workflows/test-image.yml
+++ b/.github/workflows/test-image.yml
@@ -52,7 +52,7 @@ concurrency:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-iso.yml@96da5ad926a365cb7d2fbde1d1d207253dd1c861  # main @ 2026-04-14 (xorriso post-patch with -boot_image any replay — .github#33, re-brands grub menu while preserving #146 fix)
+    uses: xibo-players/.github/.github/workflows/build-iso.yml@66aa291944bb2773302afcf6e13c1cec25ad5cbc  # main @ 2026-04-14 (xorriso post-patch with -boot_image any replay — .github#33, re-brands grub menu while preserving #146 fix)
     with:
       package-name: xiboplayer-kiosk
       kickstart-file: 'kickstart/xiboplayer-kiosk.ks'


### PR DESCRIPTION
After .github#36 dropped RPM_GPG_KEY_ID, bump all four kiosk workflow pins (rpm.yml, deb.yml, image.yml, test-image.yml) to the merge commit 66aa2919. This also fixes SHA256SUMS.asc generation in image.yml — the 0.5.2 release published unsigned because build-iso.yml's old path read base64 of the raw-armor secret.