### PR TITLE
feat(installer): visible feedback during install

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -36,7 +36,7 @@ jobs:
 
       # Default player for the single branded install entry. Users
       # switch to Electron/Arexibo post-install via Settings > Player.
-      iso-cmdline-append: 'xibo.profile=chromium'
+      iso-cmdline-append: 'xibo.profile=chromium inst.loglevel=info'
 
       # Volume ID — stage2 lookup via inst.stage2=hd:LABEL=XIBOPLAYER
       # in the kickstart file.

--- a/.github/workflows/test-image.yml
+++ b/.github/workflows/test-image.yml
@@ -77,5 +77,5 @@ jobs:
 
       # ── Verbose debug kernel cmdline (test builds only) + default player ──
       iso-cmdline-remove: 'quiet rhgb splash'
-      iso-cmdline-append: 'xibo.profile=chromium systemd.log_level=debug inst.debug rd.shell rd.debug console=tty0 console=ttyS0,115200'
+      iso-cmdline-append: 'xibo.profile=chromium inst.loglevel=info systemd.log_level=debug inst.debug rd.shell rd.debug console=ttyS0,115200 console=tty0'
     secrets: inherit

--- a/kickstart/xiboplayer-kiosk.ks
+++ b/kickstart/xiboplayer-kiosk.ks
@@ -583,6 +583,52 @@ chown -R xibo:xibo /home/xibo
 
 # Clean dnf cache
 dnf clean all
+
+# Installer complete — tell the operator on every visible console so
+# they don't panic during the auto-reboot. Writes to tty1 AND any
+# available serial consoles. Harmless if the device is missing.
+for con in /dev/tty1 /dev/ttyS0 /dev/ttyS1; do
+  [ -w "$con" ] || continue
+  {
+    printf '\n'
+    printf '  ══════════════════════════════════════════════════════════\n'
+    printf '    xiboplayer kiosk — install complete, rebooting now\n'
+    printf '  ══════════════════════════════════════════════════════════\n'
+    printf '\n'
+  } > "$con" 2>/dev/null || true
+done
+%end
+
+# ========================================================================
+# Pre-anaconda installer banner — guarantee the operator sees
+# "we are working" feedback from the very start of the install phase.
+# ========================================================================
+# Runs BEFORE the WiFi picker and disk-detect %pre blocks (file order
+# determines %pre sequencing in anaconda). Writes to /dev/tty1 AND any
+# available serial console so the banner appears on the VGA screen,
+# Boxes/QEMU spice display, and captured serial log.
+#
+# Without this, the window between kernel handoff and anaconda's first
+# TUI paint can look like a frozen black screen — especially under
+# Boxes where the default SeaBIOS boot + Fedora stock grub skips most
+# of the familiar "loading stuff" messages.
+%pre --log=/tmp/xibo-banner.log
+for con in /dev/tty1 /dev/ttyS0 /dev/ttyS1; do
+  [ -w "$con" ] || continue
+  {
+    printf '\n\n'
+    printf '  ═══════════════════════════════════════════════════════════════\n'
+    printf '    xiboplayer kiosk  —  installing Fedora 43\n'
+    printf '  ═══════════════════════════════════════════════════════════════\n'
+    printf '\n'
+    printf '    Install takes 10-20 minutes on a good network connection.\n'
+    printf '    Do NOT power off — progress will appear below shortly.\n'
+    printf '\n'
+    printf '    Default player: Chromium  (switch post-install in Settings)\n'
+    printf '  ═══════════════════════════════════════════════════════════════\n'
+    printf '\n'
+  } > "$con" 2>/dev/null || true
+done
 %end
 
 # ========================================================================


### PR DESCRIPTION
Closes #168

## Summary

- **Console order swap** in `test-image.yml`: `console=ttyS0,115200 console=tty0` so `/dev/console` = `tty0`. Under Boxes, anaconda TUI now renders on the VGA screen instead of the non-existent serial port.
- **`inst.loglevel=info`** in both `image.yml` and `test-image.yml`: anaconda emits per-package and stage transition logs on screen.
- **Kickstart banners** in `kickstart/xiboplayer-kiosk.ks`: a `%pre` banner fires before the first WiFi-picker `%pre` (file order determines %pre sequencing); a matching closing banner fires in the final `%post` before reboot. Both write to `/dev/tty1`, `/dev/ttyS0`, `/dev/ttyS1` so the message appears on VGA, Boxes/QEMU spice, and captured serial.

## Test plan

- [ ] New test ISO boots under GNOME Boxes → branded banner visible on black-screen → anaconda TUI progresses with per-package lines → closing banner visible → auto-reboot into kiosk
- [ ] Netinstall on bare metal with serial console → same banners captured on both tty0 and ttyS0
- [ ] Regression: install still succeeds end-to-end (no kickstart syntax error from the new `%pre` / `%post` edits)