### PR TITLE
fix(installer): drop %pre banner, keep %post banner

### DIFF
--- a/kickstart/xiboplayer-kiosk.ks
+++ b/kickstart/xiboplayer-kiosk.ks
@@ -600,38 +600,6 @@ done
 %end
 
 # ========================================================================
-# Pre-anaconda installer banner — guarantee the operator sees
-# "we are working" feedback from the very start of the install phase.
-# ========================================================================
-# Runs BEFORE the WiFi picker and disk-detect %pre blocks (file order
-# determines %pre sequencing in anaconda). Writes to /dev/tty1 AND any
-# available serial console so the banner appears on the VGA screen,
-# Boxes/QEMU spice display, and captured serial log.
-#
-# Without this, the window between kernel handoff and anaconda's first
-# TUI paint can look like a frozen black screen — especially under
-# Boxes where the default SeaBIOS boot + Fedora stock grub skips most
-# of the familiar "loading stuff" messages.
-%pre --log=/tmp/xibo-banner.log
-for con in /dev/tty1 /dev/ttyS0 /dev/ttyS1; do
-  [ -w "$con" ] || continue
-  {
-    printf '\n\n'
-    printf '  ═══════════════════════════════════════════════════════════════\n'
-    printf '    xiboplayer kiosk  —  installing Fedora 43\n'
-    printf '  ═══════════════════════════════════════════════════════════════\n'
-    printf '\n'
-    printf '    Install takes 10-20 minutes on a good network connection.\n'
-    printf '    Do NOT power off — progress will appear below shortly.\n'
-    printf '\n'
-    printf '    Default player: Chromium  (switch post-install in Settings)\n'
-    printf '  ═══════════════════════════════════════════════════════════════\n'
-    printf '\n'
-  } > "$con" 2>/dev/null || true
-done
-%end
-
-# ========================================================================
 # Pre-anaconda WiFi picker (#72) — whiptail TUI for WiFi-only machines
 # ========================================================================
 # Runs BEFORE anaconda's network phase so the user never sees the complex


### PR DESCRIPTION
Closes #170

## Summary

- Drop the `%pre` banner added in PR #169. anaconda on Fedora 43+ runs inside tmux (panes `1:main* 2:shell 3:log 4:storage-log 5:program-log 6:packaging-log`), and our direct `printf` to `/dev/tty1` bypasses tmux → visual collision with anaconda's own log stream.
- Keep everything else from #169: `inst.loglevel=info` (works), console= swap (works), closing `%post` banner (safe — fires after tmux winds down).

## Test plan

- [ ] New test ISO boots cleanly under Boxes — anaconda's own TUI flows without banner interference
- [ ] Closing banner still visible at install end, just before auto-reboot