### PR TITLE
feat(kiosk): enable touchpad tap-to-click + tap-and-drag

### DIFF
--- a/kiosk/gnome-kiosk-script.xibo.sh
+++ b/kiosk/gnome-kiosk-script.xibo.sh
@@ -60,6 +60,14 @@ gsettings set org.gnome.desktop.screensaver picture-uri '' 2>/dev/null || true
 gsettings set org.gnome.desktop.screensaver picture-options 'none' 2>/dev/null || true
 gsettings set org.gnome.desktop.screensaver primary-color '#000000' 2>/dev/null || true
 
+# Touchpad tap-to-click + tap-and-drag for laptop-as-kiosk deployments.
+# Single tap = click, double tap = double-click, tap+hold+move = drag.
+# Layer 2 (gschema override) + Layer 4 (GDM dconf) already cover system
+# defaults and the greeter; this Layer 3 call is belt-and-braces at
+# session start to overwrite any stale per-user dconf value.
+gsettings set org.gnome.desktop.peripherals.touchpad tap-to-click true 2>/dev/null || true
+gsettings set org.gnome.desktop.peripherals.touchpad tap-and-drag true 2>/dev/null || true
+
 # Set audio volume (90%)
 wpctl set-volume @DEFAULT_AUDIO_SINK@ 0.9 2>/dev/null || true
 

--- a/mkosi-extra/etc/dconf/db/gdm.d/00-xiboplayer-kiosk
+++ b/mkosi-extra/etc/dconf/db/gdm.d/00-xiboplayer-kiosk
@@ -52,3 +52,9 @@ gtk-theme='Adwaita-dark'
 # comment in the matching 90_xiboplayer-kiosk.gschema.override.
 [org/gnome/desktop/wm/preferences]
 theme='Adwaita'
+
+# Touchpad tap-to-click — mirrors the xibo-session gschema override so
+# the GDM greeter behaves the same on laptop-as-kiosk deployments.
+[org/gnome/desktop/peripherals/touchpad]
+tap-to-click=true
+tap-and-drag=true

--- a/mkosi-extra/etc/dconf/db/gdm.d/locks/00-xiboplayer-kiosk
+++ b/mkosi-extra/etc/dconf/db/gdm.d/locks/00-xiboplayer-kiosk
@@ -26,3 +26,5 @@
 /org/gnome/desktop/screensaver/picture-uri
 /org/gnome/desktop/screensaver/picture-options
 /org/gnome/desktop/screensaver/primary-color
+/org/gnome/desktop/peripherals/touchpad/tap-to-click
+/org/gnome/desktop/peripherals/touchpad/tap-and-drag

--- a/mkosi-extra/usr/share/glib-2.0/schemas/90_xiboplayer-kiosk.gschema.override
+++ b/mkosi-extra/usr/share/glib-2.0/schemas/90_xiboplayer-kiosk.gschema.override
@@ -80,3 +80,14 @@ picture-uri=''
 picture-uri-dark=''
 picture-options='none'
 primary-color='#000000'
+
+# Touchpad tap-to-click + tap-and-drag — laptop-as-kiosk deployments
+# expect the "tap to click" behavior most desktop OSes ship by default.
+# Without this, operators have to physically press the touchpad to click,
+# which is especially awkward during first-boot zenity menus. Fedora's
+# @^minimal-environment inherits the upstream GNOME default (false), so
+# setting it explicitly is required — relying on inheritance is brittle
+# across GNOME versions.
+[org.gnome.desktop.peripherals.touchpad]
+tap-to-click=true
+tap-and-drag=true


### PR DESCRIPTION
Closes #172

## Summary

Three-layer GSettings change so laptop-as-kiosk deployments get tap-to-click behavior at both the GDM greeter and the xibo kiosk session:

- **Layer 2** — `mkosi-extra/usr/share/glib-2.0/schemas/90_xiboplayer-kiosk.gschema.override`: `[org.gnome.desktop.peripherals.touchpad] tap-to-click=true, tap-and-drag=true`
- **Layer 3** — `kiosk/gnome-kiosk-script.xibo.sh`: `gsettings set ... tap-to-click true` + `tap-and-drag true` at session start
- **Layer 4** — `mkosi-extra/etc/dconf/db/gdm.d/00-xiboplayer-kiosk` + `locks/00-xiboplayer-kiosk`: greeter defaults + lock to prevent per-user overrides

Fedora's `@^minimal-environment` inherits the upstream GNOME schema default (false); Workstation's true comes from `fedora-release-workstation` overrides we don't pull in. Setting explicitly avoids version-skew surprises.

## Test plan

- [ ] Fresh install on a laptop → first-boot zenity menu is navigable with taps alone (no pad presses)
- [ ] Double-tap behaves as double-click (consistent with GNOME/Wayland desktop expectations)
- [ ] Ctrl+R reconfigure menu usable with taps
- [ ] No regression on systems with a real mouse (setting is touchpad-specific, ignored by mouse devices)