### PR TITLE
fix(iso): drop XIBOPLAYER volume ID, keep stock Fedora volid

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -38,9 +38,11 @@ jobs:
       # switch to Electron/Arexibo post-install via Settings > Player.
       iso-cmdline-append: 'xibo.profile=chromium inst.loglevel=info'
 
-      # Volume ID — stage2 lookup via inst.stage2=hd:LABEL=XIBOPLAYER
-      # in the kickstart file.
-      iso-volid: 'XIBOPLAYER'
+      # Volume ID: left at Fedora's default so libosinfo / GNOME Boxes
+      # / virt-install recognise the ISO as Fedora 43 and pre-fill their
+      # OS picker. We ARE installing Fedora (+ a kickstart), so it's
+      # legitimate — stage2 / kickstart lookup uses the ipxe / mkksiso
+      # mechanisms, not a LABEL-based match on the volid.
     secrets: inherit
 
   # ──────────────────────────────────────────────────────────────────

--- a/.github/workflows/test-image.yml
+++ b/.github/workflows/test-image.yml
@@ -73,7 +73,8 @@ jobs:
         Test this media & install Fedora 43|Test media and install xiboplayer kiosk
         Install Fedora 43 in basic graphics mode|Install xiboplayer kiosk (basic graphics)
         Rescue a Fedora system|Rescue xiboplayer kiosk system
-      iso-volid: 'XIBOPLAYER'
+      # Volume ID kept at Fedora default so Boxes/libosinfo auto-detects
+      # (see image.yml for rationale).
 
       # ── Verbose debug kernel cmdline (test builds only) + default player ──
       iso-cmdline-remove: 'quiet rhgb splash'


### PR DESCRIPTION
Closes #175 — rationale in the issue. No kickstart or iPXE reference to the custom volid exists; mkksiso preserves the source ISO volid when `-V` is omitted, so GNOME Boxes / libosinfo auto-detect the ISO as Fedora 43.