### PR TITLE
fix(grub): default to install entry, not test-media

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -33,6 +33,7 @@ jobs:
         Test this media & install Fedora 43|Test media and install xiboplayer kiosk
         Install Fedora 43 in basic graphics mode|Install xiboplayer kiosk (basic graphics)
         Rescue a Fedora system|Rescue xiboplayer kiosk system
+        set default="1"|set default="0"
 
       # Default player for the single branded install entry. Users
       # switch to Electron/Arexibo post-install via Settings > Player.

--- a/.github/workflows/test-image.yml
+++ b/.github/workflows/test-image.yml
@@ -73,6 +73,7 @@ jobs:
         Test this media & install Fedora 43|Test media and install xiboplayer kiosk
         Install Fedora 43 in basic graphics mode|Install xiboplayer kiosk (basic graphics)
         Rescue a Fedora system|Rescue xiboplayer kiosk system
+        set default="1"|set default="0"
       # Volume ID kept at Fedora default so Boxes/libosinfo auto-detects
       # (see image.yml for rationale).
 


### PR DESCRIPTION
Closes #177 — one-line `iso-grub-replacements` addition: `set default="1"|set default="0"`. Operators no longer have to hit the timer before the arrow-key to skip the media checksum.