### PR TITLE
feat(kiosk): block Ctrl+T + silence routine dunst popups

### DIFF
--- a/kiosk/dunstrc
+++ b/kiosk/dunstrc
@@ -72,3 +72,21 @@
     foreground = "#ffffff"
     frame_color = "#ff0000"
     timeout = 0
+
+# Hide low + normal urgency notifications. Rationale: kiosk mode fires a
+# lot of routine status_notify / notify-send calls (WiFi connecting, CMS
+# waiting, player restarting, etc.) that previously popped up constantly
+# and felt noisy. They still reach dunst's history buffer (queryable via
+# dunstctl) and the journal — just no screen popup.
+#
+# Only "-u critical" notifications display (operator-initiated Ctrl+I /
+# Ctrl+D, and genuine failure alerts). The notify-send defaults to
+# "normal" so older call sites stay silent by default — intentional.
+# Any caller that wants visible output must pass "-u critical" explicitly.
+[hide-low]
+    urgency = low
+    skip_display = yes
+
+[hide-normal]
+    urgency = normal
+    skip_display = yes

--- a/kiosk/keyd-xibo.conf
+++ b/kiosk/keyd-xibo.conf
@@ -8,9 +8,13 @@ leftcontrol = layer(xibo_ctrl)
 i = command(/usr/share/xiboplayer-kiosk/xibo-keyd-run.sh /usr/share/xiboplayer-kiosk/xibo-show-ip.sh)
 r = command(/usr/share/xiboplayer-kiosk/xibo-keyd-run.sh /usr/share/xiboplayer-kiosk/xibo-reconfigure)
 d = command(/usr/share/xiboplayer-kiosk/xibo-keyd-run.sh /usr/share/xiboplayer-kiosk/xibo-debug-dump.sh)
-# Ctrl+S opens a shell via the shared wrapper. Not Ctrl+T — Chromium
-# intercepts Ctrl+T as "new tab" even in kiosk mode, so that binding
-# would open a phantom tab instead of a terminal.
+# Block Ctrl+T — Chromium's default "new tab" shortcut leaks through
+# even in --kiosk mode and spawns a phantom tab behind the player.
+# keyd captures the chord at kernel level so Chromium never sees it.
+t = noop
+# Ctrl+S opens a shell via the shared wrapper. Chose Ctrl+S over Ctrl+T
+# originally because of the Chromium leak; with t = noop above, Ctrl+T
+# is now also safe to remap to something else in the future if wanted.
 #
 # The wrapper (xibo-keyd-open-terminal.sh) picks the first terminal
 # it finds from the list ptyxis → kgx → gnome-terminal → xterm. On

--- a/kiosk/xibo-debug-dump.sh
+++ b/kiosk/xibo-debug-dump.sh
@@ -280,7 +280,7 @@ echo "xibo-debug-dump: wrote $TARBALL ($SIZE)"
 # print to stderr as well in case this script is run from a non-graphical
 # context (e.g. SSH or a systemd unit with no DISPLAY).
 if command -v notify-send >/dev/null 2>&1; then
-    notify-send -t 15000 "Xibo debug dump" \
+    notify-send -u critical -t 15000 "Xibo debug dump" \
         "$TARBALL ($SIZE)
 Copy to USB or email to support." 2>/dev/null || true
 fi

--- a/kiosk/xibo-show-ip.sh
+++ b/kiosk/xibo-show-ip.sh
@@ -13,4 +13,4 @@ CMS=$(grep -oP '"address"\s*:\s*"\K[^"]+' "${XIBO_DATA_DIR}/cms.json" 2>/dev/nul
 PLAYER=$(basename "$(readlink /etc/alternatives/xiboplayer 2>/dev/null)" 2>/dev/null || echo "unknown")
 VERSION=$(rpm -q --queryformat '%{VERSION}-%{RELEASE}' xiboplayer-kiosk 2>/dev/null || echo "unknown")
 BUILD_DATE=$(rpm -q --queryformat '%{BUILDTIME:date}' xiboplayer-kiosk 2>/dev/null || echo "unknown")
-notify-send -t 8000 "Xibo Status" "IP: $IP\nVersion: $VERSION\nBuilt: $BUILD_DATE\nPlayer: $PLAYER\nCMS: $CMS\nStatus: $STATUS"
+notify-send -u critical -t 8000 "Xibo Status" "IP: $IP\nVersion: $VERSION\nBuilt: $BUILD_DATE\nPlayer: $PLAYER\nCMS: $CMS\nStatus: $STATUS"

--- a/rpm/xiboplayer-kiosk.spec
+++ b/rpm/xiboplayer-kiosk.spec
@@ -1,6 +1,6 @@
 Name:           xiboplayer-kiosk
 Version:        0.5.2
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Kiosk session scripts for Xibo digital signage players
 
 License:        AGPLv3+
@@ -201,6 +201,14 @@ install -Dm644 mkosi-extra/etc/chromium/policies/managed/xiboplayer-kiosk.json %
 /usr/bin/dconf update &>/dev/null || :
 
 %changelog
+* Thu Apr 16 2026 Pau Aliagas <pau@xiboplayer.org> - 0.5.2-3
+- keyd: block Ctrl+T in kiosk (was leaking through Chromium --kiosk and
+  spawning phantom new tabs behind the player).
+- dunst: hide low + normal urgency notifications; only critical pops up.
+  Operator-initiated Ctrl+I (show IP) and Ctrl+D (debug dump) promoted
+  to critical so they still appear. Routine status_notify calls silently
+  log to dunst history + journal without cluttering the screen.
+
 * Thu Apr 16 2026 Pau Aliagas <pau@xiboplayer.org> - 0.5.2-2
 - Touchpad tap-to-click + tap-and-drag (#172, #179), start gsd-mouse so
   gschema keys reach libinput. Drop XIBOPLAYER volid so Boxes auto-detects


### PR DESCRIPTION
Closes #182. Bundles both UX fixes in one kiosk-RPM-only commit + Release bump to 0.5.2-3. See issue for full rationale.