### PR TITLE
fix(dunst): match_urgency vs urgency, restore critical popups

### DIFF
--- a/kiosk/dunstrc
+++ b/kiosk/dunstrc
@@ -83,10 +83,16 @@
 # Ctrl+D, and genuine failure alerts). The notify-send defaults to
 # "normal" so older call sites stay silent by default — intentional.
 # Any caller that wants visible output must pass "-u critical" explicitly.
+#
+# IMPORTANT: the match criterion is `match_urgency`, NOT `urgency`. In
+# dunst 1.9+ `urgency` in a rule is the SET action (overrides the
+# notification's urgency). Writing `urgency = low` here with no match
+# criterion applies to EVERY notification, demoting them all to low
+# AND skipping display — which silently killed even critical popups.
 [hide-low]
-    urgency = low
+    match_urgency = low
     skip_display = yes
 
 [hide-normal]
-    urgency = normal
+    match_urgency = normal
     skip_display = yes

--- a/rpm/xiboplayer-kiosk.spec
+++ b/rpm/xiboplayer-kiosk.spec
@@ -1,6 +1,6 @@
 Name:           xiboplayer-kiosk
 Version:        0.5.2
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Kiosk session scripts for Xibo digital signage players
 
 License:        AGPLv3+
@@ -201,6 +201,13 @@ install -Dm644 mkosi-extra/etc/chromium/policies/managed/xiboplayer-kiosk.json %
 /usr/bin/dconf update &>/dev/null || :
 
 %changelog
+* Thu Apr 16 2026 Pau Aliagas <pau@xiboplayer.org> - 0.5.2-4
+- dunstrc: fix hide-low/hide-normal rules — match criterion is
+  match_urgency, not urgency (which is the SET action). Previous rules
+  had no match criterion so matched every notification and silenced
+  even critical popups — Ctrl+I / Ctrl+D hit dunst history but never
+  displayed.
+
 * Thu Apr 16 2026 Pau Aliagas <pau@xiboplayer.org> - 0.5.2-3
 - keyd: block Ctrl+T in kiosk (was leaking through Chromium --kiosk and
   spawning phantom new tabs behind the player).


### PR DESCRIPTION
Closes #184. One-word fix per rule. Release bump 3 → 4.