### PR TITLE
fix(keyd): drop `t = noop` — broke other ctrl chords

### DIFF
--- a/kiosk/keyd-xibo.conf
+++ b/kiosk/keyd-xibo.conf
@@ -8,13 +8,14 @@ leftcontrol = layer(xibo_ctrl)
 i = command(/usr/share/xiboplayer-kiosk/xibo-keyd-run.sh /usr/share/xiboplayer-kiosk/xibo-show-ip.sh)
 r = command(/usr/share/xiboplayer-kiosk/xibo-keyd-run.sh /usr/share/xiboplayer-kiosk/xibo-reconfigure)
 d = command(/usr/share/xiboplayer-kiosk/xibo-keyd-run.sh /usr/share/xiboplayer-kiosk/xibo-debug-dump.sh)
-# Block Ctrl+T — Chromium's default "new tab" shortcut leaks through
-# even in --kiosk mode and spawns a phantom tab behind the player.
-# keyd captures the chord at kernel level so Chromium never sees it.
-t = noop
-# Ctrl+S opens a shell via the shared wrapper. Chose Ctrl+S over Ctrl+T
-# originally because of the Chromium leak; with t = noop above, Ctrl+T
-# is now also safe to remap to something else in the future if wanted.
+# Ctrl+S opens a shell via the shared wrapper. Not Ctrl+T — Chromium
+# intercepts Ctrl+T as "new tab" even in kiosk mode, so that binding
+# would open a phantom tab instead of a terminal.
+#
+# Attempted block Ctrl+T via `t = noop` in 0.5.2-3 but it silently
+# broke the other command() bindings in the same layer (Ctrl+I /
+# Ctrl+D / Ctrl+S). Reverted in 0.5.2-5. Ctrl+T phantom tabs can be
+# addressed via a Chromium managed-policy file instead if needed.
 #
 # The wrapper (xibo-keyd-open-terminal.sh) picks the first terminal
 # it finds from the list ptyxis → kgx → gnome-terminal → xterm. On

--- a/rpm/xiboplayer-kiosk.spec
+++ b/rpm/xiboplayer-kiosk.spec
@@ -1,6 +1,6 @@
 Name:           xiboplayer-kiosk
 Version:        0.5.2
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Kiosk session scripts for Xibo digital signage players
 
 License:        AGPLv3+
@@ -201,6 +201,13 @@ install -Dm644 mkosi-extra/etc/chromium/policies/managed/xiboplayer-kiosk.json %
 /usr/bin/dconf update &>/dev/null || :
 
 %changelog
+* Thu Apr 16 2026 Pau Aliagas <pau@xiboplayer.org> - 0.5.2-5
+- keyd: drop `t = noop` added in 0.5.2-3 — it silently broke the other
+  command() bindings in the xibo_ctrl layer (Ctrl+I / Ctrl+D / Ctrl+S
+  stopped working; only Ctrl+R survived). Ctrl+T phantom-tab blocking
+  will be addressed via GSD custom-keybinding or Chromium managed
+  policy in a follow-up.
+
 * Thu Apr 16 2026 Pau Aliagas <pau@xiboplayer.org> - 0.5.2-4
 - dunstrc: fix hide-low/hide-normal rules — match criterion is
   match_urgency, not urgency (which is the SET action). Previous rules


### PR DESCRIPTION
Closes #186. Revert one-liner + Release bump 4 → 5. Ctrl+T blocking moves to GSD / Chromium-policy approach in a follow-up.