### PR TITLE
chore(kiosk): undo dunst/gsd-mouse churn, restore pre-0.5.2-2 session

### DIFF
--- a/kiosk/dunstrc
+++ b/kiosk/dunstrc
@@ -72,27 +72,3 @@
     foreground = "#ffffff"
     frame_color = "#ff0000"
     timeout = 0
-
-# Hide low + normal urgency notifications. Rationale: kiosk mode fires a
-# lot of routine status_notify / notify-send calls (WiFi connecting, CMS
-# waiting, player restarting, etc.) that previously popped up constantly
-# and felt noisy. They still reach dunst's history buffer (queryable via
-# dunstctl) and the journal — just no screen popup.
-#
-# Only "-u critical" notifications display (operator-initiated Ctrl+I /
-# Ctrl+D, and genuine failure alerts). The notify-send defaults to
-# "normal" so older call sites stay silent by default — intentional.
-# Any caller that wants visible output must pass "-u critical" explicitly.
-#
-# IMPORTANT: the match criterion is `match_urgency`, NOT `urgency`. In
-# dunst 1.9+ `urgency` in a rule is the SET action (overrides the
-# notification's urgency). Writing `urgency = low` here with no match
-# criterion applies to EVERY notification, demoting them all to low
-# AND skipping display — which silently killed even critical popups.
-[hide-low]
-    match_urgency = low
-    skip_display = yes
-
-[hide-normal]
-    match_urgency = normal
-    skip_display = yes

--- a/kiosk/gnome-kiosk-script.xibo.sh
+++ b/kiosk/gnome-kiosk-script.xibo.sh
@@ -19,18 +19,6 @@ sleep 2
 # Import display environment into systemd user manager
 systemctl --user import-environment WAYLAND_DISPLAY DISPLAY XDG_RUNTIME_DIR
 
-# Start GNOME Settings Daemon plugins that push gsettings into the live
-# input/display stack (gnome-kiosk's minimal session target does NOT
-# auto-activate these, unlike gnome-session).
-#
-# Mouse plugin (#xxx): applies org.gnome.desktop.peripherals.touchpad
-# keys (tap-to-click, tap-and-drag, natural-scroll, etc.) to libinput
-# devices. Without it the gschema defaults sit inert and touchpad taps
-# don't register as clicks in GTK apps — notably the first-boot zenity
-# picker. --no-block so session startup isn't delayed if the service
-# fails for any reason.
-systemctl --user start --no-block org.gnome.SettingsDaemon.Mouse.service 2>/dev/null || true
-
 # Disable screen blanking and power management.
 # This is Layer 3 (runtime session gsettings) of the 4-layer power mgmt fix
 # — belt-and-braces guard against any stray user-level dconf override that

--- a/kiosk/xibo-debug-dump.sh
+++ b/kiosk/xibo-debug-dump.sh
@@ -280,7 +280,7 @@ echo "xibo-debug-dump: wrote $TARBALL ($SIZE)"
 # print to stderr as well in case this script is run from a non-graphical
 # context (e.g. SSH or a systemd unit with no DISPLAY).
 if command -v notify-send >/dev/null 2>&1; then
-    notify-send -u critical -t 15000 "Xibo debug dump" \
+    notify-send -t 15000 "Xibo debug dump" \
         "$TARBALL ($SIZE)
 Copy to USB or email to support." 2>/dev/null || true
 fi

--- a/kiosk/xibo-show-ip.sh
+++ b/kiosk/xibo-show-ip.sh
@@ -13,4 +13,4 @@ CMS=$(grep -oP '"address"\s*:\s*"\K[^"]+' "${XIBO_DATA_DIR}/cms.json" 2>/dev/nul
 PLAYER=$(basename "$(readlink /etc/alternatives/xiboplayer 2>/dev/null)" 2>/dev/null || echo "unknown")
 VERSION=$(rpm -q --queryformat '%{VERSION}-%{RELEASE}' xiboplayer-kiosk 2>/dev/null || echo "unknown")
 BUILD_DATE=$(rpm -q --queryformat '%{BUILDTIME:date}' xiboplayer-kiosk 2>/dev/null || echo "unknown")
-notify-send -u critical -t 8000 "Xibo Status" "IP: $IP\nVersion: $VERSION\nBuilt: $BUILD_DATE\nPlayer: $PLAYER\nCMS: $CMS\nStatus: $STATUS"
+notify-send -t 8000 "Xibo Status" "IP: $IP\nVersion: $VERSION\nBuilt: $BUILD_DATE\nPlayer: $PLAYER\nCMS: $CMS\nStatus: $STATUS"

--- a/rpm/xiboplayer-kiosk.spec
+++ b/rpm/xiboplayer-kiosk.spec
@@ -1,6 +1,6 @@
 Name:           xiboplayer-kiosk
 Version:        0.5.2
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        Kiosk session scripts for Xibo digital signage players
 
 License:        AGPLv3+
@@ -201,6 +201,19 @@ install -Dm644 mkosi-extra/etc/chromium/policies/managed/xiboplayer-kiosk.json %
 /usr/bin/dconf update &>/dev/null || :
 
 %changelog
+* Thu Apr 16 2026 Pau Aliagas <pau@xiboplayer.org> - 0.5.2-6
+- Undo the dunst/gsd-mouse iteration churn accumulated in 0.5.2-2 → -5:
+  (1) drop the gsd-mouse startup line in gnome-kiosk-script.xibo.sh —
+  it broke dunst's follow=mouse query on Wayland; (2) drop the
+  [hide-low] / [hide-normal] dunst rules — both urgency= and
+  match_urgency= forms silenced every notification on this dunst
+  version; (3) revert the `-u critical` flag on Ctrl+I / Ctrl+D
+  notify-send calls — stock "normal" urgency was fine once the rules
+  are gone. Kiosk session back to pre-churn behavior. Touchpad
+  tap-to-click gschema default (#172) kept — Mutter reads it directly
+  on Wayland. Ctrl+T phantom-tab and routine-popup silencing deferred
+  to follow-up issues with a different approach.
+
 * Thu Apr 16 2026 Pau Aliagas <pau@xiboplayer.org> - 0.5.2-5
 - keyd: drop `t = noop` added in 0.5.2-3 — it silently broke the other
   command() bindings in the xibo_ctrl layer (Ctrl+I / Ctrl+D / Ctrl+S


### PR DESCRIPTION
Closes #189. Single forward commit that undoes the three problematic runtime changes accumulated today (gsd-mouse start, dunst hide rules, -u critical promotion). Keeps all the orthogonal good work. Release bump 5 → 6.