### PR TITLE
fix(atomic): derive date once to avoid midnight race

### DIFF
--- a/.github/workflows/atomic.yml
+++ b/.github/workflows/atomic.yml
@@ -24,6 +24,25 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # ── Compute date ONCE so all jobs share the same value ──
+  # Without this, ISO-build jobs and the release job each call
+  # $(date +%Y%m%d) independently — if the workflow crosses midnight
+  # UTC, filenames get 20260416 but the R2 directory gets 20260417
+  # and the website composable 404s.
+  compute-date:
+    name: Compute build date
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.date.outputs.version }}
+      tag: ${{ steps.date.outputs.tag }}
+    steps:
+      - name: Set date
+        id: date
+        run: |
+          DATE=$(date +%Y%m%d)
+          echo "version=${DATE}" >> "$GITHUB_OUTPUT"
+          echo "tag=atomic-${DATE}" >> "$GITHUB_OUTPUT"
+
   # ── Pre-flight: wait for current xiboplayer-kiosk RPM to appear ──
   # On tag-triggered runs, this workflow fires concurrently with
   # rpm.yml. The atomic Containerfile then runs `dnf install
@@ -166,7 +185,7 @@ jobs:
 
   build-iso-x86_64:
     name: Build ISO (x86_64)
-    needs: build-oci-x86_64
+    needs: [build-oci-x86_64, compute-date]
     if: ${{ !cancelled() && needs.build-oci-x86_64.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -176,15 +195,7 @@ jobs:
 
       - name: Determine version
         id: version
-        run: |
-          # Atomic ISOs ALWAYS use date-based versioning (YYYYMMDD) for
-          # both R2 paths and filenames, regardless of whether this is a
-          # tag push or a scheduled/dispatch build. The kiosk semver
-          # (v0.5.2) is only used for OCI image tags — not for ISOs.
-          # This keeps the naming convention consistent with what the
-          # website composable (useKioskImages.ts) expects: LATEST
-          # contains "atomic-YYYYMMDD", filenames use just "YYYYMMDD".
-          echo "version=$(date +%Y%m%d)" >> "$GITHUB_OUTPUT"
+        run: echo "version=${{ needs.compute-date.outputs.version }}" >> "$GITHUB_OUTPUT"
 
       - name: Pull OCI image (with retry)
         run: |
@@ -238,7 +249,7 @@ jobs:
 
   build-iso-aarch64:
     name: Build ISO (aarch64)
-    needs: build-oci-aarch64
+    needs: [build-oci-aarch64, compute-date]
     if: ${{ !cancelled() && needs.build-oci-aarch64.result == 'success' }}
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
@@ -248,15 +259,7 @@ jobs:
 
       - name: Determine version
         id: version
-        run: |
-          # Atomic ISOs ALWAYS use date-based versioning (YYYYMMDD) for
-          # both R2 paths and filenames, regardless of whether this is a
-          # tag push or a scheduled/dispatch build. The kiosk semver
-          # (v0.5.2) is only used for OCI image tags — not for ISOs.
-          # This keeps the naming convention consistent with what the
-          # website composable (useKioskImages.ts) expects: LATEST
-          # contains "atomic-YYYYMMDD", filenames use just "YYYYMMDD".
-          echo "version=$(date +%Y%m%d)" >> "$GITHUB_OUTPUT"
+        run: echo "version=${{ needs.compute-date.outputs.version }}" >> "$GITHUB_OUTPUT"
 
       - name: Pull OCI image (with retry)
         run: |
@@ -310,7 +313,7 @@ jobs:
 
   release:
     name: Create Release
-    needs: [build-iso-x86_64, build-iso-aarch64, push-manifest]
+    needs: [build-iso-x86_64, build-iso-aarch64, push-manifest, compute-date]
     if: always() && (needs.build-iso-x86_64.result == 'success' || needs.build-iso-aarch64.result == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -321,16 +324,8 @@ jobs:
       - name: Determine version
         id: version
         run: |
-          # Atomic ISOs ALWAYS use date-based naming, even on tag pushes.
-          # `tag` = R2 directory prefix (atomic-YYYYMMDD).
-          # `version` = bare date for ISO filenames (YYYYMMDD).
-          # The kiosk semver from the tag (v0.5.2) is used for OCI image
-          # tags only — never for ISO paths. This matches the website
-          # composable which expects LATEST to contain "atomic-YYYYMMDD"
-          # and strips the "atomic-" prefix for filenames.
-          DATE=$(date +%Y%m%d)
-          echo "tag=atomic-${DATE}" >> "$GITHUB_OUTPUT"
-          echo "version=${DATE}" >> "$GITHUB_OUTPUT"
+          echo "tag=${{ needs.compute-date.outputs.tag }}" >> "$GITHUB_OUTPUT"
+          echo "version=${{ needs.compute-date.outputs.version }}" >> "$GITHUB_OUTPUT"
 
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8


### PR DESCRIPTION
Part of #192. Adds compute-date job; all downstream jobs read from it. Prevents filename/directory mismatch when workflow crosses midnight UTC.