### PR TITLE
chore: post-rename sweep — xibo-players → xiboplayer

### DIFF
--- a/.github/workflows/atomic.yml
+++ b/.github/workflows/atomic.yml
@@ -16,7 +16,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: xibo-players/xiboplayer-kiosk
+  IMAGE_NAME: xiboplayer/xiboplayer-kiosk
   FEDORA_VERSION: '43'
 
 concurrency:
@@ -411,7 +411,7 @@ jobs:
 
           To update manually or switch from the traditional image:
           ```
-          bootc switch ghcr.io/xibo-players/xiboplayer-kiosk:43
+          bootc switch ghcr.io/xiboplayer/xiboplayer-kiosk:43
           systemctl reboot
           ```
 

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   cleanup:
-    uses: xibo-players/.github/.github/workflows/cleanup-releases.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
+    uses: xiboplayer/.github/.github/workflows/cleanup-releases.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       keep-versioned: 3
       keep-dated: 7

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   deb:
-    uses: xibo-players/.github/.github/workflows/build-deb.yml@66aa291944bb2773302afcf6e13c1cec25ad5cbc  # main
+    uses: xiboplayer/.github/.github/workflows/build-deb.yml@66aa291944bb2773302afcf6e13c1cec25ad5cbc  # main
     with:
       package-name: xiboplayer-kiosk
       deb-script: 'deb/build-deb.sh'

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-iso.yml@e54c80aa9c5a89decd9f978f082047759eddf705  # main @ 2026-04-16 (mkksiso -R native text replace, .github#40)
+    uses: xiboplayer/.github/.github/workflows/build-iso.yml@e54c80aa9c5a89decd9f978f082047759eddf705  # main @ 2026-04-16 (mkksiso -R native text replace, .github#40)
     with:
       package-name: xiboplayer-kiosk
       kickstart-file: 'kickstart/xiboplayer-kiosk.ks'
@@ -126,7 +126,7 @@ jobs:
       - name: Send repository_dispatch to xiboplayer-www
         env:
           # WWW_DISPATCH_TOKEN is a fine-grained PAT with actions:write
-          # on xibo-players/xiboplayer-www. See #86 for the setup steps.
+          # on xiboplayer/xiboplayer-www. See #86 for the setup steps.
           # If unset, this step logs a warning and exits 0 so the rest of
           # the release pipeline continues.
           GH_TOKEN: ${{ secrets.WWW_DISPATCH_TOKEN }}
@@ -148,7 +148,7 @@ jobs:
             --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/xibo-players/xiboplayer-www/dispatches \
+            /repos/xiboplayer/xiboplayer-www/dispatches \
             -f event_type=kiosk-released \
             -f "client_payload[version]=${TAG}" \
             -f "client_payload[source]=xiboplayer-kiosk" \

--- a/.github/workflows/qcow2-bootc.yml
+++ b/.github/workflows/qcow2-bootc.yml
@@ -12,7 +12,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: xibo-players/xiboplayer-kiosk
+  IMAGE_NAME: xiboplayer/xiboplayer-kiosk
   FEDORA_VERSION: '43'
 
 concurrency:

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   rpm:
-    uses: xibo-players/.github/.github/workflows/build-rpm.yml@66aa291944bb2773302afcf6e13c1cec25ad5cbc  # main
+    uses: xiboplayer/.github/.github/workflows/build-rpm.yml@66aa291944bb2773302afcf6e13c1cec25ad5cbc  # main
     with:
       package-name: xiboplayer-kiosk
       rpm-spec: 'rpm/xiboplayer-kiosk.spec'

--- a/.github/workflows/test-image.yml
+++ b/.github/workflows/test-image.yml
@@ -52,7 +52,7 @@ concurrency:
 
 jobs:
   build:
-    uses: xibo-players/.github/.github/workflows/build-iso.yml@e54c80aa9c5a89decd9f978f082047759eddf705  # main @ 2026-04-16 (mkksiso -R native text replace, .github#40)
+    uses: xiboplayer/.github/.github/workflows/build-iso.yml@e54c80aa9c5a89decd9f978f082047759eddf705  # main @ 2026-04-16 (mkksiso -R native text replace, .github#40)
     with:
       package-name: xiboplayer-kiosk
       kickstart-file: 'kickstart/xiboplayer-kiosk.ks'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Turn any PC or Raspberry Pi into a digital signage kiosk. Download a ready-made image, flash it to a USB stick or SD card, boot and connect to your Xibo CMS.
 
-**[Download kiosk images](https://github.com/xibo-players/xiboplayer-kiosk/releases/latest)** | **[Installation guide](https://www.xiboplayer.org/downloads/)** | **[First-boot guide](https://www.xiboplayer.org/guide/first-boot)**
+**[Download kiosk images](https://github.com/xiboplayer/xiboplayer-kiosk/releases/latest)** | **[Installation guide](https://www.xiboplayer.org/downloads/)** | **[First-boot guide](https://www.xiboplayer.org/guide/first-boot)**
 
 ### Images
 
@@ -21,7 +21,7 @@ Turn any PC or Raspberry Pi into a digital signage kiosk. Download a ready-made 
 | **Atomic (immutable OS, container-native updates)** | | | | |
 | Atomic ISO | x86_64 | ~3.1GB | [xiboplayer-kiosk-atomic_x86_64.iso](https://images.xiboplayer.org/xiboplayer-kiosk-atomic/atomic-20260407/xiboplayer-kiosk-atomic_20260407_x86_64.iso) | Immutable Fedora bootc kiosk. `bootc upgrade` with instant rollback. Best for fleet deployments. |
 | Atomic ISO | aarch64 | ~2.9GB | [xiboplayer-kiosk-atomic_aarch64.iso](https://images.xiboplayer.org/xiboplayer-kiosk-atomic/atomic-20260407/xiboplayer-kiosk-atomic_20260407_aarch64.iso) | Same for ARM64. RPi5 fleets, ARM kiosks. |
-| OCI Container | multi-arch | — | `ghcr.io/xibo-players/xiboplayer-kiosk:43` | Pull with podman/docker. Base for custom images or `bootc switch` from existing Fedora. |
+| OCI Container | multi-arch | — | `ghcr.io/xiboplayer/xiboplayer-kiosk:43` | Pull with podman/docker. Base for custom images or `bootc switch` from existing Fedora. |
 | **Network boot (no USB/SD card needed)** | | | | |
 | iPXE BIOS | x86 | 400KB | [xiboplayer-ipxe-bios.img](https://dl.xiboplayer.org/ipxe/xiboplayer-ipxe-bios.img) | Legacy BIOS PCs. Flash to USB or embed in PXE ROM. Boots from network, shows install menu. |
 | iPXE UEFI | x86_64 | 1.1MB | [xiboplayer-ipxe-uefi-x86_64.img](https://dl.xiboplayer.org/ipxe/xiboplayer-ipxe-uefi-x86_64.img) | Modern UEFI PCs. Chainload from existing PXE or flash to USB. |
@@ -32,16 +32,16 @@ Turn any PC or Raspberry Pi into a digital signage kiosk. Download a ready-made 
 
 | I want to... | Download |
 |--------------|----------|
-| Install on a PC with USB stick, no internet | [Everything ISO x86_64](https://github.com/xibo-players/xiboplayer-kiosk/releases/latest) |
-| Install on Raspberry Pi 5 | [Raw disk aarch64](https://github.com/xibo-players/xiboplayer-kiosk/releases/latest) — dd to SD card |
-| Test in a VM quickly | [QCOW2 x86_64](https://github.com/xibo-players/xiboplayer-kiosk/releases/latest) — import into Gnome Boxes |
+| Install on a PC with USB stick, no internet | [Everything ISO x86_64](https://github.com/xiboplayer/xiboplayer-kiosk/releases/latest) |
+| Install on Raspberry Pi 5 | [Raw disk aarch64](https://github.com/xiboplayer/xiboplayer-kiosk/releases/latest) — dd to SD card |
+| Test in a VM quickly | [QCOW2 x86_64](https://github.com/xiboplayer/xiboplayer-kiosk/releases/latest) — import into Gnome Boxes |
 | Deploy 50 identical kiosks with fleet updates | [Atomic ISO](https://images.xiboplayer.org/xiboplayer-kiosk-atomic/atomic-20260407/xiboplayer-kiosk-atomic_20260407_x86_64.iso) + `bootc upgrade` |
 | Network boot a room of PCs | [iPXE UEFI](https://dl.xiboplayer.org/ipxe/xiboplayer-ipxe-uefi-x86_64.img) + [boot.ipxe](https://dl.xiboplayer.org/ipxe/boot.ipxe) |
-| Rebase existing Fedora to kiosk | `bootc switch ghcr.io/xibo-players/xiboplayer-kiosk:43` |
+| Rebase existing Fedora to kiosk | `bootc switch ghcr.io/xiboplayer/xiboplayer-kiosk:43` |
 | Install on existing Fedora via RPM | `sudo dnf install xiboplayer-release && sudo dnf install xiboplayer-kiosk xiboplayer-chromium` |
 | Install on Ubuntu/Debian | See [downloads page](https://www.xiboplayer.org/downloads/) |
 
-**[Download images](https://github.com/xibo-players/xiboplayer-kiosk/releases/latest)** — Default login: `xibo` / `xibo` — change your password after first boot.
+**[Download images](https://github.com/xiboplayer/xiboplayer-kiosk/releases/latest)** — Default login: `xibo` / `xibo` — change your password after first boot.
 
 ### What's included
 
@@ -109,7 +109,7 @@ sudo apt update && sudo apt install xiboplayer-kiosk
 Boot from Fedora netinstall and add to kernel command line:
 
 ```
-inst.ks=https://raw.githubusercontent.com/xibo-players/xiboplayer-kiosk/main/kickstart/xiboplayer-kiosk.ks
+inst.ks=https://raw.githubusercontent.com/xiboplayer/xiboplayer-kiosk/main/kickstart/xiboplayer-kiosk.ks
 ```
 
 ## Files Installed

--- a/atomic/Containerfile
+++ b/atomic/Containerfile
@@ -3,8 +3,8 @@
 # Minimal bootc-based image: fedora-bootc + gdm + gnome-kiosk + codecs + players.
 # ~1.5 GB smaller than Silverblue-based image by starting from a minimal base.
 #
-# Build:  podman build -t ghcr.io/xibo-players/xiboplayer-kiosk:43 -f atomic/Containerfile .
-# Update: bootc switch --transport registry ghcr.io/xibo-players/xiboplayer-kiosk:43
+# Build:  podman build -t ghcr.io/xiboplayer/xiboplayer-kiosk:43 -f atomic/Containerfile .
+# Update: bootc switch --transport registry ghcr.io/xiboplayer/xiboplayer-kiosk:43
 #
 # Base: fedora-bootc (systemd + kernel + dnf, no desktop) — 1.0 GB compressed
 # vs Silverblue (full GNOME desktop + apps) — 2.5 GB compressed
@@ -28,7 +28,7 @@ RUN dnf install -y \
 # Xiboplayer repos (adds keyd COPR + GPG key)
 ARG RELEASE_VER=43-7
 RUN dnf install -y \
-    https://github.com/xibo-players/xibo-players.github.io/releases/download/v${RELEASE_VER}/xiboplayer-release-${RELEASE_VER}.fc43.noarch.rpm && \
+    https://github.com/xiboplayer/xiboplayer.github.io/releases/download/v${RELEASE_VER}/xiboplayer-release-${RELEASE_VER}.fc43.noarch.rpm && \
     dnf clean all
 
 # Display manager + kiosk compositor (minimal GNOME, no apps)

--- a/docs/IMAGE_AUDIT_PLAN.md
+++ b/docs/IMAGE_AUDIT_PLAN.md
@@ -49,7 +49,7 @@ For each image type, extract the package list and compare:
 guestfish -a disk.qcow2 -i : rpm -qa > qcow2-packages.txt
 
 # From Atomic OCI (inspect container)
-podman run --rm ghcr.io/xibo-players/xiboplayer-kiosk:43 rpm -qa > atomic-packages.txt
+podman run --rm ghcr.io/xiboplayer/xiboplayer-kiosk:43 rpm -qa > atomic-packages.txt
 
 # From kickstart (parse %packages + %post dnf commands)
 grep -v '^#\|^-\|^%' <(sed -n '/%packages/,/%end/p' kickstart/xiboplayer-kiosk.ks) > kickstart-packages.txt
@@ -141,7 +141,7 @@ diff <(sort qcow2-packages.txt) <(sort atomic-packages.txt)
 guestfish -a disk.qcow2 -i : find / | grep -E "gnome-kiosk-script|xiboplayer-setup|firstboot|sysusers|tmpfiles|doas.conf|AccountsService"
 
 # For Atomic OCI
-podman run --rm ghcr.io/xibo-players/xiboplayer-kiosk:43 find / -name "gnome-kiosk-script*" -o -name "xiboplayer-setup*" -o -name "*firstboot*" -o -name "doas.conf" 2>/dev/null
+podman run --rm ghcr.io/xiboplayer/xiboplayer-kiosk:43 find / -name "gnome-kiosk-script*" -o -name "xiboplayer-setup*" -o -name "*firstboot*" -o -name "doas.conf" 2>/dev/null
 ```
 
 ---

--- a/docs/TEST_PLAN_0.5.x.md
+++ b/docs/TEST_PLAN_0.5.x.md
@@ -101,17 +101,17 @@ Each stage is pass/fail. A stage "passes" only when ALL its checkpoints tick.
 
 | # | Bug | Source | Fix status | Verified |
 |---|---|---|---|---|
-| 1 | Player fails to start after CMS auth (Stage E blocker) | [#145](https://github.com/xibo-players/xiboplayer-kiosk/issues/145) + Sing7 #70, #94, #96 | ⏳ open | |
-| 2 | xorriso GRUB overlay breaks VM kernel auto-detect on some VM configs | [#146](https://github.com/xibo-players/xiboplayer-kiosk/issues/146) + Sing7 #98 | ⏳ open | |
-| 3 | Raspberry Pi 4 install can't find bootable partition | [#57](https://github.com/xibo-players/xiboplayer-kiosk/issues/57) (Yunus1903) | ⏳ open | |
-| 4 | anaconda --device-link error | [#58](https://github.com/xibo-players/xiboplayer-kiosk/issues/58) (0x0-0xf) | ⏳ open | |
+| 1 | Player fails to start after CMS auth (Stage E blocker) | [#145](https://github.com/xiboplayer/xiboplayer-kiosk/issues/145) + Sing7 #70, #94, #96 | ⏳ open | |
+| 2 | xorriso GRUB overlay breaks VM kernel auto-detect on some VM configs | [#146](https://github.com/xiboplayer/xiboplayer-kiosk/issues/146) + Sing7 #98 | ⏳ open | |
+| 3 | Raspberry Pi 4 install can't find bootable partition | [#57](https://github.com/xiboplayer/xiboplayer-kiosk/issues/57) (Yunus1903) | ⏳ open | |
+| 4 | anaconda --device-link error | [#58](https://github.com/xiboplayer/xiboplayer-kiosk/issues/58) (0x0-0xf) | ⏳ open | |
 
 ## Enhancement tracker (not release-blockers)
 
 | # | Request | Source | Status |
 |---|---|---|---|
-| E1 | "Locality" unified menu — Lang + Keyboard + Timezone in one category | [#147](https://github.com/xibo-players/xiboplayer-kiosk/issues/147) + Sing7 #76, #80 | design pending |
-| E2 | Reconfigure window visual polish | [#148](https://github.com/xibo-players/xiboplayer-kiosk/issues/148) + Sing7 #98 | design pending |
+| E1 | "Locality" unified menu — Lang + Keyboard + Timezone in one category | [#147](https://github.com/xiboplayer/xiboplayer-kiosk/issues/147) + Sing7 #76, #80 | design pending |
+| E2 | Reconfigure window visual polish | [#148](https://github.com/xiboplayer/xiboplayer-kiosk/issues/148) + Sing7 #98 | design pending |
 | E3 | Headless first-boot via captive portal (DNSMASQ + Apache) | horizon2026 (0x0) | memory tracked |
 | E4 | Plymouth branding (6-slide carousel + anaconda sidebar) | PR4 blueprint | blueprint ready |
 | E5 | Drop deprecated shell scripts (xibo-first-boot.sh etc.) | PR3 blueprint | ready for 0.5.1 |


### PR DESCRIPTION
## Summary

Residual references to the old org/repo names after today's GitHub org rename (\`xibo-players\` → \`xiboplayer\`) and the gh-pages repo rename (\`xibo-players.github.io\` → \`xiboplayer.github.io\`).

## Updated

- \`README.md\` — download URLs (×4), ghcr.io image path (×2), kickstart raw URL, bootc switch example.
- \`atomic/Containerfile\` — header build/update example commands + dnf install URL into the renamed gh-pages repo.
- \`.github/workflows/image.yml:151\` — \`api.github.com\` POST URL for \`repository_dispatch\` into xiboplayer-www. **Load-bearing**: POST URLs don't follow GitHub's 301 redirects after a rename.
- 7 workflows' \`uses: xibo-players/.github/...\` SHA-pinned references repointed.
- \`IMAGE_NAME\` env vars in \`atomic.yml\` + \`qcow2-bootc.yml\`.
- Docs (\`IMAGE_AUDIT_PLAN.md\`, \`TEST_PLAN_0.5.x.md\`) — issue links cosmetic.

## Intentionally NOT touched

- \`CHANGELOG.md\` historical entries.
- \`ipxe/boot.ipxe\` + \`kickstart/xiboplayer-kiosk.ks\` — already-installed kiosks have these baked in; raw.githubusercontent.com follows GET redirects so new boots still work.
- \`mkosi-extra/\` + \`mkosi.sandbox/etc/yum.repos.d/xibo-players.repo\` — the file name + \`[section_id]\` are the dnf repo identifier on fielded kiosks; renaming would orphan their dnf cache until next image refresh. Separate PR coordinated with a fleet upgrade if/when wanted.

## Test plan

- [x] \`grep -rn 'xibo-players' .\` post-edit returns only the intentionally-untouched files.
- [ ] CI: lint + workflow syntax.
- [ ] Smoke: next deb/rpm build run validates the \`uses:\` redirects + the image.yml POST URL update.

## Refs

- Memory entry: \`reference_github_org_rename_local_remote_url_gotcha.md\` (extended today with the GET-vs-POST asymmetry rule).
- Earlier waves: \`xiboplayer/xiboplayer.github.io#17\` (rename), \`xiboplayer/.github#42\` (shared workflow URLs).